### PR TITLE
Convert learning goal into a minimal roadmap

### DIFF
--- a/soft-skills-back/router/learning_goal.py
+++ b/soft-skills-back/router/learning_goal.py
@@ -135,3 +135,21 @@ def delete_learning_goal(
     
     except APIException as err:
         raise_http_exception(err)
+
+
+@router.post(
+    "/{id}/convert-to-roadmap",
+    summary="Convert learning goal to roadmap",
+    status_code=status.HTTP_201_CREATED,
+)
+def convert_learning_goal_to_roadmap(
+    id: str,
+    token_data: TokenData = Depends(decode_jwt_token),
+    session: Session = Depends(get_session)
+):
+    try:
+        result = learning_goal_service.convert_to_roadmap(UUID(id), token_data.user_id, session)
+        return result
+    
+    except APIException as err:
+        raise_http_exception(err)

--- a/soft-skills-front/src/config/api.ts
+++ b/soft-skills-front/src/config/api.ts
@@ -15,7 +15,8 @@ export const api = {
     create: `${BASE_URL}/learning-goals`,
     getAllByUser: `${BASE_URL}/users/me/learning-goals`,
     byId: (id: string) => `${BASE_URL}/learning-goals/${id}`,
-    getObjectives: (id: string) => `${BASE_URL}/learning-goals/${id}/objectives`
+    getObjectives: (id: string) => `${BASE_URL}/learning-goals/${id}/objectives`,
+    convertToRoadmap: (id: string) => `${BASE_URL}/learning-goals/${id}/convert-to-roadmap`
   },
   objectives: {
     create: `${BASE_URL}/objectives`,

--- a/soft-skills-front/src/features/learn-to-learn/api/LearningGoals.ts
+++ b/soft-skills-front/src/features/learn-to-learn/api/LearningGoals.ts
@@ -8,6 +8,7 @@ import {
   FetchLearningGoalResponse,
   UpdateLearningGoalPayload,
   UpdateLearningGoalResponse,
+  ConvertToRoadmapResponse,
 } from '../types/planner/learningGoals.api'
 import { FetchObjectivesResponse } from '../types/planner/objectives.api'
 
@@ -98,5 +99,17 @@ export async function getObjectivesByLearningGoal(
   const url = `${api.learningGoals.getObjectives(learningGoalId)}?${params.toString()}`
 
   const response = await fetchWithAuth(url)
+  return response
+}
+
+export async function convertLearningGoalToRoadmap(
+  learningGoalId: string
+): Promise<ConvertToRoadmapResponse> {
+  const url = api.learningGoals.convertToRoadmap(learningGoalId)
+
+  const response = await fetchWithAuth(url, {
+    method: "POST",
+  })
+
   return response
 }

--- a/soft-skills-front/src/features/learn-to-learn/components/planner/GoalCard.tsx
+++ b/soft-skills-front/src/features/learn-to-learn/components/planner/GoalCard.tsx
@@ -4,11 +4,13 @@ import {
   LinearProgress,
   Stack,
   IconButton,
-  Paper
+  Paper,
+  CircularProgress
 } from '@mui/material'
 import ArrowForwardIosIcon from '@mui/icons-material/ArrowForwardIos'
 import CalendarTodayIcon from '@mui/icons-material/CalendarToday'
 import DeleteIcon from '@mui/icons-material/Delete'
+import RouteIcon from '@mui/icons-material/Route'
 import { LearningGoal } from '../../types/planner/planner.models' 
 import { useState } from 'react'
 import { formatDateString } from '../../../../utils/formatDate'
@@ -18,9 +20,11 @@ import { useLearningGoalStore } from '../../store/useLearningGoalStore'
 interface GoalCardProps {
   goal: LearningGoal
   onDeleteClick?: () => void
+  onCreateRoadmapClick?: () => void
+  isConverting?: boolean
 }
 
-const GoalCard = ({ goal, onDeleteClick }: GoalCardProps) => {
+const GoalCard = ({ goal, onDeleteClick, onCreateRoadmapClick, isConverting }: GoalCardProps) => {
   const setSelectedGoalId = useLearningGoalStore(state => state.setSelectedGoalId)
   const navigate = useNavigate()
   const [hovered, setHovered] = useState(false)
@@ -70,12 +74,23 @@ const GoalCard = ({ goal, onDeleteClick }: GoalCardProps) => {
 
         <Stack direction="row" alignItems="center" spacing={1}>
           {hovered && (
-            <IconButton size="small" onClick={onDeleteClick}>
-              <DeleteIcon fontSize="small"/>
-            </IconButton>
-          )
-
-          }
+            <>
+              <IconButton 
+                size="small" 
+                onClick={onCreateRoadmapClick}
+                disabled={isConverting}
+              >
+                {isConverting ? (
+                  <CircularProgress size={16} />
+                ) : (
+                  <RouteIcon fontSize="small"/>
+                )}
+              </IconButton>
+              <IconButton size="small" onClick={onDeleteClick}>
+                <DeleteIcon fontSize="small"/>
+              </IconButton>
+            </>
+          )}
           <IconButton 
             size="small"
             onClick={handleNavigate}

--- a/soft-skills-front/src/features/learn-to-learn/components/planner/GoalsSection.tsx
+++ b/soft-skills-front/src/features/learn-to-learn/components/planner/GoalsSection.tsx
@@ -9,8 +9,9 @@ import {
 } from '@mui/material'
 import AddIcon from '@mui/icons-material/Add';
 import { useLearningGoalStore } from '../../store/useLearningGoalStore'
-import { useLearningGoals, useCreateLearningGoal, useDeleteLearningGoal } from '../../hooks/useLearningGoals'
+import { useLearningGoals, useCreateLearningGoal, useDeleteLearningGoal, useConvertLearningGoalToRoadmap } from '../../hooks/useLearningGoals'
 import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 import GoalCard from './GoalCard'
 import AddGoalModal from './AddGoalModal'
 import { CreateLearningGoalPayload } from '../../types/planner/learningGoals.api'
@@ -19,6 +20,7 @@ import { LearningGoal } from '../../types/planner/planner.models'
 import ConfirmDeleteModal from '../ConfirmDeleteModal'
 
 const GoalsSection = () => {
+  const navigate = useNavigate()
   const [addModalOpen, setAddModalOpen] = useState(false)
   const [inputTitle, setInputTitle] = useState('')
   const [deleteModalOpen, setDeleteModalOpen] = useState(false)
@@ -34,6 +36,13 @@ const GoalsSection = () => {
   const { data, isLoading, isFetching } = useLearningGoals(offset, limit)
   const { mutateAsync: createLearningGoal } = useCreateLearningGoal()
   const { mutateAsync: deleteLearningGoal } = useDeleteLearningGoal()
+  const { mutateAsync: convertToRoadmap, isPending: isConverting } = useConvertLearningGoalToRoadmap(
+    (roadmapId: string) => {
+      setTimeout(() => {
+        navigate(`/learn/roadmaps/${roadmapId}`)
+      }, 1500) 
+    }
+  )
 
   useEffect(() => {
     if (data?.total !== undefined) {
@@ -73,6 +82,10 @@ const GoalsSection = () => {
   const handleCloseDeleteModal = () => {
     setDeleteModalOpen(false)
     setGoalToDelete(null)
+  }
+
+  const handleCreateRoadmapClick = async (goal: LearningGoal) => {
+    await convertToRoadmap(goal.learningGoalId)
   }
 
   return (
@@ -173,6 +186,8 @@ const GoalsSection = () => {
                     key={goal.learningGoalId} 
                     goal={goal} 
                     onDeleteClick={() => handleOpenDeleteModal(goal)}
+                    onCreateRoadmapClick={() => handleCreateRoadmapClick(goal)}
+                    isConverting={isConverting}
                   />
                 ))}
               </Stack>

--- a/soft-skills-front/src/features/learn-to-learn/hooks/useLearningGoals.ts
+++ b/soft-skills-front/src/features/learn-to-learn/hooks/useLearningGoals.ts
@@ -1,5 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { getUserLearningGoals, getLearningGoalById, createLearningGoal, updateLearningGoal, deleteLearningGoal } from '../api/LearningGoals'
+import { getUserLearningGoals, getLearningGoalById, createLearningGoal, updateLearningGoal, deleteLearningGoal, convertLearningGoalToRoadmap } from '../api/LearningGoals'
 
 import { CreateLearningGoalPayload, UpdateLearningGoalPayload, FetchLearningGoalsResponse } from '../types/planner/learningGoals.api'
 import { useToastStore } from '../../../store/useToastStore'
@@ -222,6 +222,33 @@ export const useDeleteLearningGoal = () => {
     },
     onSuccess: ({ message }) => {
       showToast(message || 'Goal deleted successfully', 'success')
+    }
+  })
+}
+
+export const useConvertLearningGoalToRoadmap = (onSuccess?: (roadmapId: string) => void) => {
+  const { showToast } = useToastStore()
+
+  return useMutation({
+    mutationFn: async (learningGoalId: string) => {
+      const response = await convertLearningGoalToRoadmap(learningGoalId)
+      return response
+    },
+    onSuccess: (response) => {
+      const { message, roadmapId } = response
+      
+      showToast(
+        message || 'Learning goal converted to roadmap successfully!', 
+        'success',
+        3000
+      )
+      
+      if (onSuccess && roadmapId) {
+        onSuccess(roadmapId)
+      }
+    },
+    onError: (error: Error) => {
+      showToast(error.message || 'Error converting goal to roadmap', 'error')
     }
   })
 }

--- a/soft-skills-front/src/features/learn-to-learn/types/planner/learningGoals.api.ts
+++ b/soft-skills-front/src/features/learn-to-learn/types/planner/learningGoals.api.ts
@@ -51,3 +51,8 @@ export interface DeleteLearningGoalResponse {
   message: string
   learningGoalId: string
 }
+
+export interface ConvertToRoadmapResponse {
+  message: string
+  roadmapId: string
+}


### PR DESCRIPTION
What:
- Add POST /api/v1/learning-goals/{id}/convert-to-roadmap
- Build a roadmap from the goal’s objectives (and tasks) only
- Exclude user-learning-goal data (progress, tracking, history, stats, etc.)
- Use layout order if present; otherwise use seed order (order_index) for first render
- Return the created roadmap (id, title, description, objectives, tasks, optional layout)

Why:
- Create a shareable visual plan without leaking user-specific goal data
- Keep the roadmap clean and lightweight for editing and presentation
- Makes conversion a single, explicit action with predictable output