### PR TITLE
Add detail view for objectives

### DIFF
--- a/soft-skills-back/schema/objective.py
+++ b/soft-skills-back/schema/objective.py
@@ -16,8 +16,10 @@ class ObjectiveCreate(ObjectiveBase):
 
 class ObjectiveRead(ObjectiveBase):
     objective_id: UUID4
-    started_at: datetime | None
-    completed_at: datetime | None 
+    created_at: datetime | None = Field(default=None)
+    updated_at: datetime | None = Field(default=None)
+    started_at: datetime | None = Field(default=None)
+    completed_at: datetime | None = Field(default=None)
 
     model_config={"json_schema_extra": {"example": OBJECTIVE_READ_EXAMPLE}}
 

--- a/soft-skills-front/src/config/api.ts
+++ b/soft-skills-front/src/config/api.ts
@@ -20,6 +20,7 @@ export const api = {
   },
   objectives: {
     create: `${BASE_URL}/objectives`,
+    byId: (id: string) => `${BASE_URL}/objectives/${id}`,
     delete: (id: string) => `${BASE_URL}/objectives/${id}`
   },
   roadmap: {

--- a/soft-skills-front/src/features/learn-to-learn/api/Objectives.ts
+++ b/soft-skills-front/src/features/learn-to-learn/api/Objectives.ts
@@ -1,6 +1,6 @@
 import { fetchWithAuth } from '../../../utils/fetchWithAuth'
 import { api } from '../../../config/api'
-import { CreateObjectivePayload, CreateObjectiveResponse, DeleteObjectiveResponse } from '../types/planner/objectives.api'
+import { CreateObjectivePayload, CreateObjectiveResponse, DeleteObjectiveResponse, FetchObjectiveResponse, UpdateObjectivePayload } from '../types/planner/objectives.api'
 
 export const createObjective = async (
   payload: CreateObjectivePayload
@@ -9,6 +9,32 @@ export const createObjective = async (
   
   const response = await fetchWithAuth(url, {
     method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(payload),
+  })
+
+  return response
+}
+
+export const getObjectiveById = async (
+  id: string
+): Promise<FetchObjectiveResponse> => {
+  const url = api.objectives.byId(id)
+  
+  const response = await fetchWithAuth(url)
+  return response
+}
+
+export const updateObjective = async (
+  id: string,
+  payload: UpdateObjectivePayload
+): Promise<FetchObjectiveResponse> => {
+  const url = api.objectives.byId(id)
+  
+  const response = await fetchWithAuth(url, {
+    method: 'PATCH',
     headers: {
       'Content-Type': 'application/json',
     },

--- a/soft-skills-front/src/features/learn-to-learn/components/objectives/ObjectivesList.tsx
+++ b/soft-skills-front/src/features/learn-to-learn/components/objectives/ObjectivesList.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
 import {
   Box,
   Typography,
@@ -16,12 +17,14 @@ import ConfirmDeleteModal from '../ConfirmDeleteModal'
 import { CreateObjectivePayload, Objective } from '../../types/planner/objectives.api'
 import { FilterOption, TabValue } from '../../types/ui/filter.types'
 import { Priority, Status } from '../../types/common.enums'
+import { formatDateToDateTime } from '../../utils/dateUtils'
 
 interface ObjectivesListProps {
   learningGoalId: string
 }
 
 const ObjectivesList = ({ learningGoalId }: ObjectivesListProps) => {
+  const navigate = useNavigate()
   const [isModalOpen, setIsModalOpen] = useState(false)
   const [deleteModalOpen, setDeleteModalOpen] = useState(false)
   const [objectiveToDelete, setObjectiveToDelete] = useState<Objective | null>(null)
@@ -54,14 +57,6 @@ const ObjectivesList = ({ learningGoalId }: ObjectivesListProps) => {
     setIsModalOpen(false)
   }
 
-  const formatDateToDateTime = (dateString: string): string => {
-    if (dateString.includes('T')) {
-      return dateString
-    }
-    
-
-    return `${dateString}T23:59:59Z`
-  }
 
   const handleSubmit = async (objective: CreateObjectivePayload) => {
     const objectiveWithLearningGoal: CreateObjectivePayload = {
@@ -101,6 +96,9 @@ const ObjectivesList = ({ learningGoalId }: ObjectivesListProps) => {
   const handleCloseDeleteModal = () => {
     setDeleteModalOpen(false)
     setObjectiveToDelete(null)
+  }
+  const handleOpenViewModal = (objective: Objective) => {
+    navigate(`/learn/planner/goals/${learningGoalId}/objectives/${objective.objectiveId}`)
   }
 
   const getTabFilters = (tab: TabValue) => {
@@ -284,6 +282,7 @@ const ObjectivesList = ({ learningGoalId }: ObjectivesListProps) => {
         onRowsPerPageChange={handleChangeRowsPerPage}
         hasFiltersApplied={hasFiltersApplied}
         onDeleteClick={handleOpenDeleteModal}
+        onViewClick={handleOpenViewModal}
       />
 
       <AddObjectiveModal

--- a/soft-skills-front/src/features/learn-to-learn/components/objectives/ObjectivesTable.tsx
+++ b/soft-skills-front/src/features/learn-to-learn/components/objectives/ObjectivesTable.tsx
@@ -18,25 +18,9 @@ import VisibilityIcon from '@mui/icons-material/Visibility'
 import DeleteIcon from '@mui/icons-material/Delete'
 import { Objective } from '../../types/planner/objectives.api'
 import { formatDateString } from '../../../../utils/formatDate'
+import { getPriorityColor, getStatusChipColor, formatStatus } from '../../utils/objectiveUtils'
 
-const formatStatus = (status: string): string => {
-  return status.replace('_', ' ')
-}
 
-const getStatusColor = (status: string): 'success' | 'info' | 'warning' | 'default' => {
-  if (status === 'completed') return 'success'
-  if (status === 'in_progress') return 'info'
-  if (status === 'paused') return 'warning'
-  
-  return 'default'
-}
-
-const getPriorityColor = (priority: string): 'error' | 'warning' | 'default' => {
-  if (priority === 'high') return 'error'
-  if (priority === 'medium') return 'warning'
-  
-  return 'default'
-}
 
 const calculateProgress = (completedTasks: number, totalTasks: number): number => {
   return totalTasks > 0 ? Math.round((completedTasks / totalTasks) * 100) : 0
@@ -53,6 +37,7 @@ interface ObjectivesTableProps {
   onRowsPerPageChange: (event: React.ChangeEvent<HTMLInputElement>) => void
   hasFiltersApplied: boolean
   onDeleteClick?: (objective: Objective) => void
+  onViewClick?: (objective: Objective) => void
 }
 
 const ObjectivesTable = ({
@@ -65,7 +50,8 @@ const ObjectivesTable = ({
   onPageChange,
   onRowsPerPageChange,
   hasFiltersApplied,
-  onDeleteClick
+  onDeleteClick,
+  onViewClick
 }: ObjectivesTableProps) => {
   if (isLoading) {
     return (
@@ -222,7 +208,7 @@ const ObjectivesTable = ({
                   <Chip 
                     label={formatStatus(objective.status)} 
                     size="small" 
-                    color={getStatusColor(objective.status)}
+                    color={getStatusChipColor(objective.status)}
                   />
                 </TableCell>
                 <TableCell>
@@ -296,6 +282,7 @@ const ObjectivesTable = ({
                   >
                     <IconButton 
                       size="small" 
+                      onClick={() => onViewClick?.(objective)}
                       sx={{ 
                         color: 'text.secondary',
                         '&:hover': {

--- a/soft-skills-front/src/features/learn-to-learn/components/ui/InlineEditableDate.tsx
+++ b/soft-skills-front/src/features/learn-to-learn/components/ui/InlineEditableDate.tsx
@@ -1,0 +1,111 @@
+import { Box, Typography, TextField } from '@mui/material'
+import { ReactNode, useState } from 'react'
+import { generateFormFieldAttributes } from '../../../../utils/formUtils'
+
+interface InlineEditableDateProps {
+  label: string
+  value: string | null
+  onSave: (value: string | null) => void
+  icon?: ReactNode
+  id?: string
+  name?: string
+}
+
+const InlineEditableDate = ({
+  label,
+  value,
+  onSave,
+  icon,
+  id,
+  name,
+}: InlineEditableDateProps) => {
+  const [hovered, setHovered] = useState(false)
+  const fieldAttributes = generateFormFieldAttributes(label, 'inline-date', id, name)
+
+  const handleChange = (newValue: string) => {
+    onSave(newValue || null)
+  }
+
+  const inputBackgroundColor = hovered ? '#f9f9f9' : 'transparent'
+
+  const formatDateForInput = (dateString: string | null) => {
+    if (!dateString) return ''
+    try {
+      return dateString.split('T')[0]
+    } catch {
+      return ''
+    }
+  }
+
+  return (
+    <Box
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      sx={{
+        transition: 'box-shadow 0.2s ease-in-out',
+        borderRadius: 1,
+        display: 'flex',
+        gap: 3,
+        alignItems: 'center',
+      }}
+    >
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 1,
+          minWidth: '100px',
+          flexShrink: 0,
+        }}
+      >
+        {icon && (
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              color: 'text.secondary',
+              fontSize: '1.2rem',
+            }}
+          >
+            {icon}
+          </Box>
+        )}
+        <Typography 
+          variant="subtitle2" 
+          color="text.secondary" 
+          sx={{
+            fontWeight: 400,
+          }}
+          gutterBottom
+        >
+          {label}
+        </Typography>
+      </Box>
+
+      <TextField
+        type="date"
+        value={formatDateForInput(value)}
+        onChange={(e) => handleChange(e.target.value)}
+        variant="standard"
+        size="small"
+        id={fieldAttributes.id}
+        name={fieldAttributes.name}
+        sx={{
+          backgroundColor: inputBackgroundColor,
+          transition: 'background-color 0.2s ease-in-out',
+          padding: 1,
+        }}
+        slotProps={{
+          input: {
+            disableUnderline: true,
+            sx: {
+              fontSize: '0.875rem',
+            },
+          },
+        }}
+      />
+    </Box>
+  )
+}
+
+export default InlineEditableDate

--- a/soft-skills-front/src/features/learn-to-learn/components/ui/InlineEditableField.tsx
+++ b/soft-skills-front/src/features/learn-to-learn/components/ui/InlineEditableField.tsx
@@ -1,6 +1,7 @@
 import { Box, TextField, Typography } from '@mui/material'
 import { ReactNode } from 'react'
 import { useState, useEffect } from 'react'
+import { generateFormFieldAttributes } from '../../../../utils/formUtils'
 
 interface EditableFieldProps {
   label: string
@@ -16,6 +17,8 @@ interface EditableFieldProps {
   customInputStyles?: object
   customTextFieldStyles?: object
   icon?: ReactNode
+  id?: string
+  name?: string
 }
 
 const InlineEditableField = ({
@@ -27,6 +30,8 @@ const InlineEditableField = ({
   customInputStyles,
   customTextFieldStyles,
   icon,
+  id,
+  name,
 }: EditableFieldProps) => {
   const [value, setValue] = useState(defaultValue)
   const [hovered, setHovered] = useState(false)
@@ -39,6 +44,7 @@ const InlineEditableField = ({
   const shouldShowLabel = !disableDefaultDecoration
 
   const inputBackgroundColor = shouldShowShadow ? '#f9f9f9' : 'transparent'
+  const fieldAttributes = generateFormFieldAttributes(label, 'inline-editable', id, name)
 
   const defaultTitleInputStyles = {
     fontSize: '2rem',
@@ -125,6 +131,8 @@ const InlineEditableField = ({
           }
         }}
         multiline={multiline}
+        id={fieldAttributes.id}
+        name={fieldAttributes.name}
         slotProps={{
           input: {
             disableUnderline: true,

--- a/soft-skills-front/src/features/learn-to-learn/components/ui/InlineEditableSelect.tsx
+++ b/soft-skills-front/src/features/learn-to-learn/components/ui/InlineEditableSelect.tsx
@@ -1,0 +1,143 @@
+import { Box, Typography, Select, MenuItem, FormControl, Chip } from '@mui/material'
+import { ReactNode, useState } from 'react'
+import { PriorityColorValue } from '../../types/ui/colors'
+import { generateFormFieldAttributes } from '../../../../utils/formUtils'
+
+interface SelectOption {
+  value: string
+  label: string
+}
+
+interface InlineEditableSelectProps {
+  label: string
+  value: string
+  options: SelectOption[]
+  onSave: (value: string) => void
+  icon?: ReactNode
+  getColor?: (value: string) => PriorityColorValue
+  id?: string
+  name?: string
+}
+
+const InlineEditableSelect = ({
+  label,
+  value,
+  options,
+  onSave,
+  icon,
+  getColor,
+  id,
+  name,
+}: InlineEditableSelectProps) => {
+  const [hovered, setHovered] = useState(false)
+  const fieldAttributes = generateFormFieldAttributes(label, 'inline-select', id, name)
+
+  const handleChange = (newValue: string) => {
+    onSave(newValue)
+  }
+
+  const inputBackgroundColor = hovered ? '#f9f9f9' : 'transparent'
+  
+  const currentOption = options.find(option => option.value === value)
+  const currentLabel = currentOption?.label || value
+  
+  const chipColor = getColor ? getColor(value) : 'default'
+
+  return (
+    <Box
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      sx={{
+        transition: 'box-shadow 0.2s ease-in-out',
+        borderRadius: 1,
+        display: 'flex',
+        gap: 3,
+        alignItems: 'center',
+      }}
+    >
+      <Box
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 1,
+          minWidth: '100px',
+          flexShrink: 0,
+        }}
+      >
+        {icon && (
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              color: 'text.secondary',
+              fontSize: '1.2rem',
+            }}
+          >
+            {icon}
+          </Box>
+        )}
+        <Typography 
+          variant="subtitle2" 
+          color="text.secondary" 
+          sx={{
+            fontWeight: 400,
+          }}
+          gutterBottom
+        >
+          {label}
+        </Typography>
+      </Box>
+
+      <FormControl 
+        size="small" 
+        sx={{
+          backgroundColor: inputBackgroundColor,
+          transition: 'background-color 0.2s ease-in-out',
+          padding: 1,
+        }}
+      >
+        <Select
+          value={value}
+          onChange={(e) => handleChange(e.target.value)}
+          variant="standard"
+          disableUnderline
+          id={fieldAttributes.id}
+          name={fieldAttributes.name}
+          sx={{
+            fontSize: '0.875rem',
+            '& .MuiSelect-select': {
+              padding: '4px 0',
+            },
+          }}
+          renderValue={() => (
+            <Chip
+              label={currentLabel}
+              size="small"
+              color={chipColor}
+              sx={{
+                fontSize: '0.75rem',
+                height: '24px',
+              }}
+            />
+          )}
+        >
+          {options.map((option) => (
+            <MenuItem key={option.value} value={option.value}>
+              <Chip
+                label={option.label}
+                size="small"
+                color={getColor ? getColor(option.value) : 'default'}
+                sx={{
+                  fontSize: '0.75rem',
+                  height: '24px',
+                }}
+              />
+            </MenuItem>
+          ))}
+        </Select>
+      </FormControl>
+    </Box>
+  )
+}
+
+export default InlineEditableSelect

--- a/soft-skills-front/src/features/learn-to-learn/hooks/useLearningGoals.ts
+++ b/soft-skills-front/src/features/learn-to-learn/hooks/useLearningGoals.ts
@@ -123,7 +123,7 @@ export const useUpdateLearningGoal = () => {
   return useMutation({
     mutationFn: async ({ id, payload }: { id: string; payload: UpdateLearningGoalPayload }) => {
       const { data, message } = await updateLearningGoal(id, payload)
-      return { goal: data, message, changed: true }
+      return { goal: data, message }
     },
     onMutate: async ({ id, payload }) => {
       await queryClient.cancelQueries({ queryKey: ['learningGoals', 'detail', id] })

--- a/soft-skills-front/src/features/learn-to-learn/pages/LearningGoalDetail.tsx
+++ b/soft-skills-front/src/features/learn-to-learn/pages/LearningGoalDetail.tsx
@@ -15,6 +15,7 @@ const LearningGoalDetail = () => {
   const navigate = useNavigate()
   const { goalId } = useParams()
   const setSelectedGoalId = useLearningGoalStore(s => s.setSelectedGoalId)
+  const setSelectedGoalTitle = useLearningGoalStore(s => s.setSelectedGoalTitle)
   
   const { data: goal, isLoading, error } = useLearningGoal(goalId || null)
   const { mutate: updateGoal, isPending: isSaving } = useUpdateLearningGoal()
@@ -31,7 +32,7 @@ const LearningGoalDetail = () => {
     impact: false
   })
 
-  const debouncedTitle = useDebounce(goalData.title)
+  const debouncedTitle = useDebounce<string>(goalData.title)
   const debouncedDescription = useDebounce(goalData.description)
   const debouncedImpact = useDebounce(goalData.impact)
 
@@ -40,6 +41,12 @@ const LearningGoalDetail = () => {
       setSelectedGoalId(goalId)
     }
   }, [goalId, setSelectedGoalId])
+
+  useEffect(() => {
+    if (goal?.title) {
+      setSelectedGoalTitle(goal.title)
+    }
+  }, [goal?.title, setSelectedGoalTitle])
 
   useEffect(() => {
     if (goal && !goalData.title && !goalData.description && !goalData.impact) {
@@ -52,22 +59,22 @@ const LearningGoalDetail = () => {
   }, [goal, goalData.title, goalData.description, goalData.impact])
 
   useEffect(() => {
-    if (hasUserInteracted.title && debouncedTitle !== undefined) {
+    if (hasUserInteracted.title && goalId && debouncedTitle !== goal?.title) {
       updateGoal({ id: goalId!, payload: { title: debouncedTitle } })
     }
-  }, [debouncedTitle, hasUserInteracted.title, goalId, updateGoal])
+  }, [debouncedTitle, hasUserInteracted.title, goalId, goal?.title, updateGoal])
 
   useEffect(() => {
-    if (hasUserInteracted.description && debouncedDescription !== undefined) {
+    if (hasUserInteracted.description && goalId && debouncedDescription !== goal?.description) {
       updateGoal({ id: goalId!, payload: { description: debouncedDescription } })
     }
-  }, [debouncedDescription, hasUserInteracted.description, goalId, updateGoal])
+  }, [debouncedDescription, hasUserInteracted.description, goalId, goal?.description, updateGoal])
 
   useEffect(() => {
-    if (hasUserInteracted.impact && debouncedImpact !== undefined) {
+    if (hasUserInteracted.impact && goalId && debouncedImpact !== goal?.impact) {
       updateGoal({ id: goalId!, payload: { impact: debouncedImpact } })
     }
-  }, [debouncedImpact, hasUserInteracted.impact, goalId, updateGoal])
+  }, [debouncedImpact, hasUserInteracted.impact, goalId, goal?.impact, updateGoal])
 
   const saveField = (field: 'title' | 'description' | 'impact', value: string) => {
     setGoalData(prev => ({

--- a/soft-skills-front/src/features/learn-to-learn/pages/ObjectiveDetail.tsx
+++ b/soft-skills-front/src/features/learn-to-learn/pages/ObjectiveDetail.tsx
@@ -1,6 +1,300 @@
+import { Box, Typography, Breadcrumbs, Link, CircularProgress, Stack, Chip, Divider } from '@mui/material'
+import { useNavigate, useParams } from 'react-router-dom'
+import { useLearningGoalStore } from '../store/useLearningGoalStore'
+import { useObjective, useUpdateObjective } from '../hooks/useObjectives'
+import NoResults from '../components/ui/NoResults'
+import InlineEditableField from '../components/ui/InlineEditableField'
+import InlineEditableSelect from '../components/ui/InlineEditableSelect'
+import InlineEditableDate from '../components/ui/InlineEditableDate'
+import DateDisplay from '../components/ui/DateDisplay'
+import { Notes, AccessTime, Flag, CalendarToday } from '@mui/icons-material'
+import { useEffect, useState } from 'react'
+import { getObjectiveStatusInfo, getObjectiveStatusChipColor, getPriorityColor } from '../utils/objectiveUtils'
+import { useDebounce } from '../hooks/useDebounce'
+import { Priority } from '../types/common.enums'
+import { formatDateToDateTime, normalizeDate } from '../utils/dateUtils'
+
 const ObjectiveDetail = () => {
+  const navigate = useNavigate()
+  const { goalId, objectiveId } = useParams()
+  const selectedGoalTitle = useLearningGoalStore(s => s.selectedGoalTitle)
+  
+  const { data: objective, isLoading, error } = useObjective(objectiveId || null)
+  const { mutate: updateObjective, isPending: isSaving } = useUpdateObjective()
+
+  const [objectiveData, setObjectiveData] = useState({
+    title: '',
+    description: '',
+    priority: Priority.Medium,
+    dueDate: null as string | null
+  })
+  
+  const [hasUserInteracted, setHasUserInteracted] = useState({
+    title: false,
+    description: false
+  })
+
+  const debouncedTitle = useDebounce<string>(objectiveData.title)
+  const debouncedDescription = useDebounce(objectiveData.description)
+
+  useEffect(() => {
+    if (objective && !objectiveData.title && !objectiveData.description) {
+      setObjectiveData({
+        title: objective.title,
+        description: objective.description,
+        priority: objective.priority,
+        dueDate: normalizeDate(objective.dueDate)
+      })
+    }
+  }, [objective, objectiveData.title, objectiveData.description])
+
+  useEffect(() => {
+    if (hasUserInteracted.title && objectiveId && debouncedTitle !== objective?.title) {
+      updateObjective({
+        id: objectiveId,
+        payload: { title: debouncedTitle }
+      })
+    }
+  }, [debouncedTitle, hasUserInteracted.title, objectiveId, objective?.title, updateObjective])
+
+  useEffect(() => {
+    if (hasUserInteracted.description && objectiveId && debouncedDescription !== objective?.description) {
+      updateObjective({
+        id: objectiveId,
+        payload: { description: debouncedDescription }
+      })
+    }
+  }, [debouncedDescription, hasUserInteracted.description, objectiveId, objective?.description, updateObjective])
+
+  const saveField = (field: 'title' | 'description', value: string) => {
+    setObjectiveData(prev => ({
+      ...prev,
+      [field]: value
+    }))
+    
+    setHasUserInteracted(prev => ({
+      ...prev,
+      [field]: true
+    }))
+  }
+
+  const savePriority = (value: string) => {
+    const priority = value as Priority
+    setObjectiveData(prev => ({
+      ...prev,
+      priority
+    }))
+
+    if (objectiveId && priority !== objective?.priority) {
+      updateObjective({
+        id: objectiveId,
+        payload: { priority }
+      })
+    }
+  }
+
+  const saveDueDate = (value: string | null) => {
+    const formattedDate = normalizeDate(value)
+    
+    setObjectiveData(prev => ({
+      ...prev,
+      dueDate: formattedDate
+    }))
+
+    if (objectiveId) {
+      const normalizedObjectiveDate = normalizeDate(objective?.dueDate || null)
+      
+      if (formattedDate !== normalizedObjectiveDate) {
+        const apiFormattedDate = formattedDate ? formatDateToDateTime(formattedDate) : undefined
+        
+        updateObjective({
+          id: objectiveId,
+          payload: { due_date: apiFormattedDate }
+        })
+      }
+    }
+  }
+
+  const priorityOptions = [
+    { value: Priority.Low, label: 'low' },
+    { value: Priority.Medium, label: 'medium' },
+    { value: Priority.High, label: 'high' }
+  ]
+
+  if (isLoading) {
+    return (
+      <Box
+        sx={{
+          maxWidth: '900px',
+          mx: 'auto',
+          px: 2,
+          py: 4,
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+          minHeight: '100vh',
+        }}
+      >
+        <CircularProgress />
+      </Box>
+    )
+  }
+
+  if (error || !objective) {
+    return (
+      <NoResults
+        title="Objective not found"
+        description="The objective you're looking for doesn't exist or may have been removed."
+        buttonText="Back to Learning Goal"
+        onButtonClick={() => navigate(`/learn/planner/goals/${goalId}`)}
+      />
+    )
+  }
+
+  const statusInfo = getObjectiveStatusInfo(objective.status, objective.startedAt, objective.completedAt)
+
   return (
-    <h1>Objective Detail</h1>
+    <Box
+      sx={{
+        maxWidth: '900px',
+        mx: 'auto',
+        px: 2,
+        py: 4,
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 2,
+      }}
+    >
+      <Breadcrumbs aria-label="breadcrumb">
+        <Link 
+          underline="hover" 
+          color="inherit" 
+          onClick={() => navigate('/learn/planner')} 
+          sx={{ 
+            cursor: 'pointer', 
+            flex: 1,
+            textAlign: 'left'
+          }}
+        >
+          Learning Goals
+        </Link>
+        <Link 
+          underline="hover" 
+          color="inherit" 
+          onClick={() => navigate(`/learn/planner/goals/${goalId}`)} 
+          sx={{ 
+            cursor: 'pointer', 
+            flex: 1,
+            textAlign: 'left'
+          }}
+        >
+          {selectedGoalTitle || 'Learning Goal'}
+        </Link>
+        <Typography color="text.primary">{objectiveData.title}</Typography>
+      </Breadcrumbs>
+
+      <Box>
+        <Stack 
+          direction="row" 
+          spacing={2} 
+          alignItems="center" 
+          justifyContent="space-between"
+          sx={{ 
+            mb: 2, 
+            width: '100%' 
+          }} 
+        >
+          <Box sx={{ flex: 1 }}>
+            <InlineEditableField
+              label="Title"
+              defaultValue={objectiveData.title}
+              onSave={(val) => saveField('title', val)}
+              disableDefaultDecoration
+            />
+          </Box>
+          
+          <Stack direction="row" spacing={2} alignItems="center">
+            {isSaving && (
+              <Chip
+                label="Saving..."
+                size="small"
+                color="info"
+                variant="outlined"
+              />
+            )}
+            
+            <Chip
+              label={statusInfo.status}
+              color={getObjectiveStatusChipColor(objective.status)}
+              size="small"
+            />
+            
+            {statusInfo.elapsedTime && (
+              <Chip
+                icon={<AccessTime />}
+                label={`Elapsed: ${statusInfo.elapsedTime}`}
+                variant="outlined"
+                size="small"
+              />
+            )}
+          </Stack>
+        </Stack>
+        
+        <InlineEditableField
+          label="Description"
+          defaultValue={objectiveData.description}
+          onSave={(val) => saveField('description', val)}
+          multiline
+          icon={<Notes />}
+        />
+
+        <InlineEditableSelect
+          label="Priority"
+          value={objectiveData.priority}
+          options={priorityOptions}
+          onSave={savePriority}
+          icon={<Flag />}
+          getColor={getPriorityColor}
+        />
+
+        <InlineEditableDate
+          label="Due Date"
+          value={objectiveData.dueDate}
+          onSave={saveDueDate}
+          icon={<CalendarToday />}
+        />
+
+        <Divider sx={{ my: 3 }} />
+
+        <DateDisplay
+          title="Dates"
+          dates={[
+            {
+              label: 'Created at',
+              value: objective.createdAt
+            },
+            {
+              label: 'Updated at',
+              value: objective.updatedAt
+            },
+            {
+              label: 'Started at',
+              value: objective.startedAt
+            },
+            {
+              label: 'Completed at',
+              value: objective.completedAt
+            },
+            {
+              label: 'Due date',
+              value: objective.dueDate
+            }
+          ]}
+        />
+
+        <Divider sx={{ my: 3 }} />
+      </Box>
+    </Box>
   )
 }
 

--- a/soft-skills-front/src/features/learn-to-learn/store/useLearningGoalStore.ts
+++ b/soft-skills-front/src/features/learn-to-learn/store/useLearningGoalStore.ts
@@ -8,6 +8,7 @@ export const useLearningGoalStore = create<ILearningGoal>()(
     immer(
       (set) => ({
         selectedGoalId: null,
+        selectedGoalTitle: null,
         isPaginating: false,
         learningGoalsPagination: {
           total: 0,
@@ -19,6 +20,12 @@ export const useLearningGoalStore = create<ILearningGoal>()(
           set((state) => {
             state.selectedGoalId = id
           }, false, "SET_SELECTED_GOAL_ID")
+        },
+
+        setSelectedGoalTitle: (title: string | null) => {
+          set((state) => {
+            state.selectedGoalTitle = title
+          }, false, "SET_SELECTED_GOAL_TITLE")
         },
 
         setIsPaginating: (value: boolean) => {

--- a/soft-skills-front/src/features/learn-to-learn/types/planner/learningGoal.store.ts
+++ b/soft-skills-front/src/features/learn-to-learn/types/planner/learningGoal.store.ts
@@ -2,10 +2,12 @@ import { PaginationState } from "../pagination"
 
 export interface ILearningGoal {
   selectedGoalId: string | null
+  selectedGoalTitle: string | null
   isPaginating: boolean
   learningGoalsPagination: PaginationState
 
   setSelectedGoalId: (id: string | null) => void
+  setSelectedGoalTitle: (title: string | null) => void
   setIsPaginating: (value: boolean) => void
   setLearningGoalsOffset: (offset: number) => void
   setLearningGoalsLimit: (limit: number) => void

--- a/soft-skills-front/src/features/learn-to-learn/types/planner/objectives.api.ts
+++ b/soft-skills-front/src/features/learn-to-learn/types/planner/objectives.api.ts
@@ -7,7 +7,8 @@ export interface Objective {
   status: Status
   priority: Priority
   dueDate: string | null
-  orderIndex: number
+  createdAt: string | null
+  updatedAt: string | null
   startedAt: string | null
   completedAt: string | null
   totalTasks: number
@@ -52,4 +53,9 @@ export interface UpdateObjectiveResponse {
 export interface DeleteObjectiveResponse {
   message: string
   objective_id: string
+}
+
+export interface FetchObjectiveResponse {
+  message: string
+  data: Objective
 }

--- a/soft-skills-front/src/features/learn-to-learn/types/ui/colors.ts
+++ b/soft-skills-front/src/features/learn-to-learn/types/ui/colors.ts
@@ -1,0 +1,33 @@
+/**
+ * Color constants for UI components
+ */
+
+// Priority colors
+export const PRIORITY_COLORS = {
+  HIGH: 'error',
+  MEDIUM: 'warning', 
+  LOW: 'default'
+} as const
+
+// Status colors
+export const STATUS_COLORS = {
+  COMPLETED: 'success',
+  IN_PROGRESS: 'info',
+  PAUSED: 'warning',
+  NOT_STARTED: 'default'
+} as const
+
+// Type for priority colors
+export type PriorityColor = typeof PRIORITY_COLORS[keyof typeof PRIORITY_COLORS]
+
+// Type for status colors
+export type StatusColor = typeof STATUS_COLORS[keyof typeof STATUS_COLORS]
+
+// Union type for all priority color values
+export type PriorityColorValue = 'error' | 'warning' | 'default'
+
+// Union type for all status color values
+export type StatusColorValue = 'success' | 'info' | 'warning' | 'default'
+
+// Union type for all chip colors
+export type ChipColorValue = PriorityColorValue | StatusColorValue

--- a/soft-skills-front/src/features/learn-to-learn/utils/dateUtils.ts
+++ b/soft-skills-front/src/features/learn-to-learn/utils/dateUtils.ts
@@ -1,0 +1,26 @@
+/**
+ * Formats a date string to match API expectations
+ * Converts YYYY-MM-DD to YYYY-MM-DDTHH:mm:ssZ format
+ */
+export const formatDateToDateTime = (dateString: string): string => {
+  if (dateString.includes('T')) {
+    return dateString
+  }
+  
+  // Add T23:59:59Z to make it end of day (consistent with create objective)
+  return `${dateString}T23:59:59Z`
+}
+
+/**
+ * Normalizes a date string to YYYY-MM-DD format for comparison
+ * Extracts the date part from ISO datetime strings
+ */
+export const normalizeDate = (dateString: string | null): string | null => {
+  if (!dateString) return null
+  try {
+    // Extract YYYY-MM-DD part from ISO date or return as-is if already in correct format
+    return dateString.split('T')[0]
+  } catch {
+    return dateString
+  }
+}

--- a/soft-skills-front/src/features/learn-to-learn/utils/learningGoalUtils.ts
+++ b/soft-skills-front/src/features/learn-to-learn/utils/learningGoalUtils.ts
@@ -1,3 +1,5 @@
+import { calculateElapsedTime } from './timeUtils'
+
 export enum LearningGoalStatusEnum {
   COMPLETED = 'Completed',
   IN_PROGRESS = 'In progress',
@@ -41,27 +43,6 @@ export function getLearningGoalStatus(
   return LearningGoalStatusEnum.NOT_STARTED
 }
 
-export function calculateElapsedTime(
-  startedAt?: string | null,
-  completedAt?: string | null
-): string | undefined {
-  if (!startedAt) {
-    return undefined
-  }
-
-  const startDate = new Date(startedAt)
-  const endDate = completedAt ? new Date(completedAt) : new Date()
-  
-  const diffInMs = endDate.getTime() - startDate.getTime()
-  const diffInDays = Math.floor(diffInMs / (1000 * 60 * 60 * 24))
-  const diffInHours = Math.floor((diffInMs % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60))
-  
-  if (diffInDays > 0) {
-    return `${diffInDays}d ${diffInHours}h`
-  }
-  
-  return `${diffInHours}h`
-}
 
 /**
  * Gets complete status information for a learning goal

--- a/soft-skills-front/src/features/learn-to-learn/utils/objectiveUtils.ts
+++ b/soft-skills-front/src/features/learn-to-learn/utils/objectiveUtils.ts
@@ -1,0 +1,76 @@
+import { Status } from '../types/common.enums'
+import { calculateElapsedTime } from './timeUtils'
+import { PRIORITY_COLORS, STATUS_COLORS, PriorityColorValue, StatusColorValue } from '../types/ui/colors'
+
+export interface ObjectiveStatusInfo {
+  status: string
+  elapsedTime?: string
+}
+
+/**
+ * General function to get status chip color
+ * Works for both objectives and learning goals
+ */
+export function getStatusChipColor(status: string): StatusColorValue {
+  switch (status) {
+    case Status.Completed:
+    case 'completed':
+      return STATUS_COLORS.COMPLETED
+    case Status.InProgress:
+    case 'in_progress':
+      return STATUS_COLORS.IN_PROGRESS
+    case Status.Paused:
+    case 'paused':
+      return STATUS_COLORS.PAUSED
+    case Status.NotStarted:
+    case 'not_started':
+    default:
+      return STATUS_COLORS.NOT_STARTED
+  }
+}
+
+/**
+ * @deprecated Use getStatusChipColor instead
+ */
+export function getObjectiveStatusChipColor(status: string): StatusColorValue {
+  return getStatusChipColor(status)
+}
+
+/**
+ * General function to format status strings
+ * Converts snake_case to readable format
+ */
+export function formatStatus(status: string): string {
+  return status.replace('_', ' ')
+}
+
+/**
+ * @deprecated Use formatStatus instead
+ */
+export function formatObjectiveStatus(status: string): string {
+  return formatStatus(status)
+}
+
+/**
+ * Gets complete status information for an objective
+ */
+export function getObjectiveStatusInfo(
+  status: string,
+  startedAt?: string | null,
+  completedAt?: string | null
+): ObjectiveStatusInfo {
+  const formattedStatus = formatObjectiveStatus(status)
+  const elapsedTime = calculateElapsedTime(startedAt, completedAt)
+  
+  return {
+    status: formattedStatus,
+    elapsedTime
+  }
+}
+
+export function getPriorityColor(priority: string): PriorityColorValue {
+  if (priority === 'high') return PRIORITY_COLORS.HIGH
+  if (priority === 'medium') return PRIORITY_COLORS.MEDIUM
+  
+  return PRIORITY_COLORS.LOW
+}

--- a/soft-skills-front/src/features/learn-to-learn/utils/timeUtils.ts
+++ b/soft-skills-front/src/features/learn-to-learn/utils/timeUtils.ts
@@ -57,3 +57,28 @@ export const formatDate = (date: Date): string => {
     hour12: false
   }).format(date)
 }
+
+/**
+ * Calculates elapsed time between start and end dates
+ */
+export function calculateElapsedTime(
+  startedAt?: string | null,
+  completedAt?: string | null
+): string | undefined {
+  if (!startedAt) {
+    return undefined
+  }
+
+  const startDate = new Date(startedAt)
+  const endDate = completedAt ? new Date(completedAt) : new Date()
+  
+  const diffInMs = endDate.getTime() - startDate.getTime()
+  const diffInDays = Math.floor(diffInMs / (1000 * 60 * 60 * 24))
+  const diffInHours = Math.floor((diffInMs % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60))
+  
+  if (diffInDays > 0) {
+    return `${diffInDays}d ${diffInHours}h`
+  }
+  
+  return `${diffInHours}h`
+}

--- a/soft-skills-front/src/routes/routes.tsx
+++ b/soft-skills-front/src/routes/routes.tsx
@@ -44,8 +44,10 @@ export const RoutesConfiguration = () => {
           <Route path='/learn' element={<LearnLayout/>}>
             <Route path='planner'>
               <Route index element={<Planner />} />
-              <Route path='goals/:goalId' element={<LearningGoalDetail />} />
-              <Route path='objectives/:objectiveId' element={<ObjectiveDetail />} />
+              <Route path='goals/:goalId'>
+                <Route index element={<LearningGoalDetail />} />
+                <Route path='objectives/:objectiveId' element={<ObjectiveDetail />} />
+              </Route>
             </Route>
             
             <Route path='dashboard' element={<Dashboard/>}></Route>

--- a/soft-skills-front/src/utils/formUtils.ts
+++ b/soft-skills-front/src/utils/formUtils.ts
@@ -1,0 +1,22 @@
+/**
+ * Generates form field attributes (id and name) based on a label
+ * @param label - The field label to base the attributes on
+ * @param prefix - Optional prefix for the id (defaults to 'field')
+ * @param customId - Optional custom id to use instead of generated one
+ * @param customName - Optional custom name to use instead of generated one
+ * @returns Object with id and name attributes
+ */
+export const generateFormFieldAttributes = (
+  label: string,
+  prefix: string = 'field',
+  customId?: string,
+  customName?: string
+) => {
+  const normalizedLabel = label.toLowerCase().replace(/\s+/g, '-')
+  const normalizedName = label.toLowerCase().replace(/\s+/g, '_')
+  
+  return {
+    id: customId || `${prefix}-${normalizedLabel}`,
+    name: customName || normalizedName
+  }
+}


### PR DESCRIPTION
What:
- Implemented objective detail page showing description, priority, and due date
- Displayed metadata (created, updated, completion timestamps)
- Prepared layout where the Kanban board for tasks will be integrated later

Why:
- To allow users to view detailed information about an objective
- This will serve as the base for adding the Kanban board visualization of tasks in upcoming changes