### PR TITLE
Add initial Board, Column, and CardList UI components

### DIFF
--- a/soft-skills-front/src/features/learn-to-learn/components/kanban/Board.tsx
+++ b/soft-skills-front/src/features/learn-to-learn/components/kanban/Board.tsx
@@ -1,0 +1,44 @@
+import { Box } from '@mui/material'
+import { ObjectiveBoard } from '../../types/kanban/board.types'
+import Column from './Column'
+
+interface BoardProps {
+  board: ObjectiveBoard
+}
+
+const Board = ({ board }: BoardProps) => {
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        gap: 2,
+        px: 1,
+        pb: 2,
+        overflow: 'auto',
+        minHeight: '400px',
+        maxHeight: '600px',
+        '&::-webkit-scrollbar': {
+          height: 6
+        },
+        '&::-webkit-scrollbar-track': {
+          backgroundColor: '#f1f1f1',
+          borderRadius: 3
+        },
+        '&::-webkit-scrollbar-thumb': {
+          backgroundColor: '#c1c1c1',
+          borderRadius: 3,
+          '&:hover': {
+            backgroundColor: '#a8a8a8'
+          }
+        },
+        backgroundColor: '#ffffff',
+      }}
+    >
+      {board.columns.map((column) => (
+        <Column key={column.id} column={column} />
+      ))}
+    </Box>
+  )
+}
+
+export default Board

--- a/soft-skills-front/src/features/learn-to-learn/components/kanban/CardList.tsx
+++ b/soft-skills-front/src/features/learn-to-learn/components/kanban/CardList.tsx
@@ -1,0 +1,27 @@
+import { Box } from '@mui/material'
+import { SubTask } from '../../types/kanban/board.types'
+import TaskCard from './TaskCard'
+
+interface CardListProps {
+  tasks: SubTask[]
+}
+
+const CardList = ({ tasks }: CardListProps) => {
+  return (
+    <Box
+      sx={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 0,
+        minHeight: 100,
+        p: 1
+      }}
+    >
+      {tasks.map((task) => (
+        <TaskCard key={task.id} task={task} />
+      ))}
+    </Box>
+  )
+}
+
+export default CardList

--- a/soft-skills-front/src/features/learn-to-learn/components/kanban/Column.tsx
+++ b/soft-skills-front/src/features/learn-to-learn/components/kanban/Column.tsx
@@ -1,0 +1,125 @@
+import { Box, Typography, Chip } from '@mui/material'
+import { TaskColumn } from '../../types/kanban/board.types'
+import CardList from './CardList'
+
+interface ColumnProps {
+  column: TaskColumn
+}
+
+const Column = ({ column }: ColumnProps) => {
+  const getColumnColor = (columnId: string) => {
+    switch (columnId) {
+      case 'todo':
+        return {
+          bg: '#f8f9fa',
+          border: '#e9ecef',
+          chipColor: 'default' as const
+        }
+      case 'in-progress':
+        return {
+          bg: '#e3f2fd',
+          border: '#bbdefb',
+          chipColor: 'info' as const
+        }
+      case 'done':
+        return {
+          bg: '#e8f5e8',
+          border: '#c8e6c9',
+          chipColor: 'success' as const
+        }
+      case 'paused':
+        return {
+          bg: '#fff3e0',
+          border: '#ffcc02',
+          chipColor: 'warning' as const
+        }
+      default:
+        return {
+          bg: '#f8f9fa',
+          border: '#e9ecef',
+          chipColor: 'default' as const
+        }
+    }
+  }
+
+  const colors = getColumnColor(column.id)
+
+  return (
+    <Box
+      sx={{
+        width: 300,
+        minWidth: 300,
+        maxWidth: 300,
+        backgroundColor: colors.bg,
+        border: `1px solid ${colors.border}`,
+        borderRadius: 2,
+        display: 'flex',
+        flexDirection: 'column',
+        maxHeight: '80vh',
+        overflow: 'hidden'
+      }}
+    >
+      <Box
+        sx={{
+          p: 2,
+          pb: 1,
+          borderBottom: `1px solid ${colors.border}`,
+          backgroundColor: 'white',
+          borderRadius: '8px 8px 0 0'
+        }}
+      >
+        <Box 
+          sx={{ 
+            display: 'flex', 
+            justifyContent: 'space-between', 
+            alignItems: 'center' 
+          }}
+        >
+          <Typography
+            variant="subtitle1"
+            sx={{
+              fontWeight: 600,
+              fontSize: '0.875rem',
+              color: 'text.primary',
+              textTransform: 'uppercase',
+              letterSpacing: '0.5px'
+            }}
+          >
+            {column.title}
+          </Typography>
+          <Chip
+            label={column.tasks.length}
+            size="small"
+            color={colors.chipColor}
+            sx={{
+              height: 20,
+              fontSize: '0.65rem',
+              fontWeight: 600
+            }}
+          />
+        </Box>
+      </Box>
+
+      <Box
+        sx={{
+          flex: 1,
+          overflow: 'auto',
+          '&::-webkit-scrollbar': {
+            width: 6
+          },
+          '&::-webkit-scrollbar-track': {
+            backgroundColor: 'transparent'
+          },
+          '&::-webkit-scrollbar-thumb': {
+            backgroundColor: 'rgba(0,0,0,0.2)',
+            borderRadius: 3
+          }
+        }}
+      >
+        <CardList tasks={column.tasks} />
+      </Box>
+    </Box>
+  )
+}
+
+export default Column

--- a/soft-skills-front/src/features/learn-to-learn/components/kanban/TaskCard.tsx
+++ b/soft-skills-front/src/features/learn-to-learn/components/kanban/TaskCard.tsx
@@ -1,0 +1,112 @@
+import { Card, CardContent, Typography, Chip, Box } from '@mui/material'
+import { CalendarToday, Flag } from '@mui/icons-material'
+import { SubTask } from '../../types/kanban/board.types'
+import { getPriorityColor } from '../../utils/objectiveUtils'
+import { formatDateString } from '../../../../utils/formatDate'
+
+interface TaskCardProps {
+  task: SubTask
+}
+
+const TaskCard = ({ task }: TaskCardProps) => {
+
+  return (
+    <Card
+      elevation={0}
+      sx={{
+        mb: 2,
+        cursor: 'pointer',
+        transition: 'all 0.2s ease-in-out',
+        border: '1px solid #e0e0e0',
+        '&:hover': {
+          borderColor: '#bdbdbd',
+          transform: 'translateY(-1px)'
+        },
+        '&:last-child': {
+          mb: 0
+        }
+      }}
+    >
+      <CardContent 
+        sx={{ 
+          p: 2, 
+          '&:last-child': { 
+            pb: 2 
+          } 
+        }}
+      >
+        <Typography 
+          variant="subtitle2" 
+          sx={{ 
+            fontWeight: 600,
+            mb: 1,
+            lineHeight: 1.3
+          }}
+        >
+          {task.title}
+        </Typography>
+        
+        {task.description && (
+          <Typography 
+            variant="body2" 
+            color="text.secondary"
+            sx={{ 
+              mb: 2,
+              fontSize: '0.75rem',
+              lineHeight: 1.4
+            }}
+          >
+            {task.description}
+          </Typography>
+        )}
+
+        <Box 
+          sx={{ 
+            display: 'flex', 
+            justifyContent: 'space-between', 
+            alignItems: 'center' 
+          }}
+        >
+          <Chip
+            icon={
+              <Flag 
+                sx={{ fontSize: '0.75rem !important' }} 
+              />
+            }
+            label={task.priority.toLowerCase()}
+            size="small"
+            color={getPriorityColor(task.priority)}
+            sx={{ 
+              height: 20,
+              fontSize: '0.65rem',
+              '& .MuiChip-icon': {
+                fontSize: '0.75rem'
+              }
+            }}
+          />
+          
+          {task.dueDate && (
+            <Box 
+              sx={{ 
+                display: 'flex', 
+                alignItems: 'center', 
+                gap: 0.5 
+              }}
+            >
+              <CalendarToday sx={{ fontSize: '0.75rem', color: 'text.secondary' }} />
+              <Typography 
+                variant="caption" 
+                color="text.secondary"
+                sx={{ fontSize: '0.65rem' }}
+              >
+                {formatDateString(task.dueDate, '', '')}
+              </Typography>
+            </Box>
+          )}
+        </Box>
+      </CardContent>
+    </Card>
+  )
+}
+
+export default TaskCard

--- a/soft-skills-front/src/features/learn-to-learn/data/kanbanData.ts
+++ b/soft-skills-front/src/features/learn-to-learn/data/kanbanData.ts
@@ -1,0 +1,104 @@
+import { ObjectiveBoard } from '../types/kanban/board.types'
+
+export const createObjectiveBoardData = (objectiveId: string, objectiveTitle: string): ObjectiveBoard => ({
+  objectiveId,
+  objectiveTitle,
+  columns: [
+    {
+      id: 'todo',
+      title: 'TO DO',
+      tasks: [
+        {
+          id: 'subtask-1',
+          title: 'Research learning methodologies',
+          description: 'Study different approaches to effective learning',
+          priority: 'HIGH',
+          status: 'TODO',
+          dueDate: '2024-02-15'
+        },
+        {
+          id: 'subtask-2',
+          title: 'Create study schedule',
+          description: 'Plan daily and weekly study sessions',
+          priority: 'MEDIUM',
+          status: 'TODO',
+          dueDate: '2024-02-10'
+        },
+        {
+          id: 'subtask-3',
+          title: 'Gather learning resources',
+          description: 'Collect books, articles, and online materials',
+          priority: 'LOW',
+          status: 'TODO',
+          dueDate: '2024-02-20'
+        }
+      ]
+    },
+    {
+      id: 'in-progress',
+      title: 'IN PROGRESS',
+      tasks: [
+        {
+          id: 'subtask-4',
+          title: 'Practice active reading techniques',
+          description: 'Apply note-taking and summarization methods',
+          priority: 'HIGH',
+          status: 'IN_PROGRESS',
+          dueDate: '2024-02-12'
+        },
+        {
+          id: 'subtask-5',
+          title: 'Set up learning environment',
+          description: 'Organize workspace and eliminate distractions',
+          priority: 'MEDIUM',
+          status: 'IN_PROGRESS',
+          dueDate: '2024-02-08'
+        }
+      ]
+    },
+    {
+      id: 'done',
+      title: 'DONE',
+      tasks: [
+        {
+          id: 'subtask-6',
+          title: 'Define learning objectives',
+          description: 'Establish clear, measurable learning goals',
+          priority: 'HIGH',
+          status: 'DONE',
+          dueDate: '2024-02-05'
+        },
+        {
+          id: 'subtask-7',
+          title: 'Install productivity apps',
+          description: 'Set up tools for time tracking and note-taking',
+          priority: 'LOW',
+          status: 'DONE',
+          dueDate: '2024-02-03'
+        }
+      ]
+    },
+    {
+      id: 'paused',
+      title: 'PAUSED',
+      tasks: [
+        {
+          id: 'subtask-8',
+          title: 'Review learning materials',
+          description: 'Go through collected resources and organize them',
+          priority: 'MEDIUM',
+          status: 'PAUSED',
+          dueDate: '2024-02-18'
+        },
+        {
+          id: 'subtask-9',
+          title: 'Create flashcards',
+          description: 'Design digital flashcards for key concepts',
+          priority: 'LOW',
+          status: 'PAUSED',
+          dueDate: '2024-02-25'
+        }
+      ]
+    }
+  ]
+})

--- a/soft-skills-front/src/features/learn-to-learn/pages/ObjectiveDetail.tsx
+++ b/soft-skills-front/src/features/learn-to-learn/pages/ObjectiveDetail.tsx
@@ -7,12 +7,14 @@ import InlineEditableField from '../components/ui/InlineEditableField'
 import InlineEditableSelect from '../components/ui/InlineEditableSelect'
 import InlineEditableDate from '../components/ui/InlineEditableDate'
 import DateDisplay from '../components/ui/DateDisplay'
+import Board from '../components/kanban/Board'
 import { Notes, AccessTime, Flag, CalendarToday } from '@mui/icons-material'
 import { useEffect, useState } from 'react'
 import { getObjectiveStatusInfo, getObjectiveStatusChipColor, getPriorityColor } from '../utils/objectiveUtils'
 import { useDebounce } from '../hooks/useDebounce'
 import { Priority } from '../types/common.enums'
 import { formatDateToDateTime, normalizeDate } from '../utils/dateUtils'
+import { createObjectiveBoardData } from '../data/kanbanData'
 
 const ObjectiveDetail = () => {
   const navigate = useNavigate()
@@ -293,6 +295,30 @@ const ObjectiveDetail = () => {
         />
 
         <Divider sx={{ my: 3 }} />
+
+        <Box sx={{ mb: 3 }}>
+          <Typography
+            variant="h6"
+            sx={{
+              fontWeight: 600,
+              color: 'text.primary',
+              mb: 1
+            }}
+          >
+            Task Breakdown
+          </Typography>
+          <Typography
+            variant="body2"
+            color="text.secondary"
+            sx={{ mb: 2 }}
+          >
+            Break down this objective into manageable sub-tasks and track their progress
+          </Typography>
+          
+          <Board 
+            board={createObjectiveBoardData(objectiveId || '', objectiveData.title)} 
+          />
+        </Box>
       </Box>
     </Box>
   )

--- a/soft-skills-front/src/features/learn-to-learn/types/kanban/board.types.ts
+++ b/soft-skills-front/src/features/learn-to-learn/types/kanban/board.types.ts
@@ -1,0 +1,20 @@
+export interface SubTask {
+  id: string
+  title: string
+  description?: string
+  priority: 'LOW' | 'MEDIUM' | 'HIGH'
+  dueDate?: string
+  status: 'TODO' | 'IN_PROGRESS' | 'PAUSED' | 'DONE'
+}
+
+export interface TaskColumn {
+  id: string
+  title: string
+  tasks: SubTask[]
+}
+
+export interface ObjectiveBoard {
+  objectiveId: string
+  objectiveTitle: string
+  columns: TaskColumn[]
+}

--- a/soft-skills-front/src/features/learn-to-learn/utils/objectiveUtils.ts
+++ b/soft-skills-front/src/features/learn-to-learn/utils/objectiveUtils.ts
@@ -69,8 +69,10 @@ export function getObjectiveStatusInfo(
 }
 
 export function getPriorityColor(priority: string): PriorityColorValue {
-  if (priority === 'high') return PRIORITY_COLORS.HIGH
-  if (priority === 'medium') return PRIORITY_COLORS.MEDIUM
+  const lowerPriority = priority.toLowerCase()
+  
+  if (lowerPriority === 'high') return PRIORITY_COLORS.HIGH
+  if (lowerPriority === 'medium') return PRIORITY_COLORS.MEDIUM
   
   return PRIORITY_COLORS.LOW
 }


### PR DESCRIPTION
What:
- Implemented Board component with horizontal layout for multiple columns
- Added Column component with header and CardList
- Created CardList component rendering placeholder cards
- Applied basic styling/layout (no drag-and-drop yet)

Why:
- Establish UI/UX structure for a Trello-like board
- Allows us to validate layout and user experience before integrating drag-and-drop