### PR TITLE
Implement drag-and-drop with type-safe helpers

### DIFF
--- a/soft-skills-front/package-lock.json
+++ b/soft-skills-front/package-lock.json
@@ -8,6 +8,8 @@
       "name": "soft-skills-front",
       "version": "0.0.0",
       "dependencies": {
+        "@atlaskit/pragmatic-drag-and-drop": "^1.7.7",
+        "@atlaskit/pragmatic-drag-and-drop-hitbox": "^1.1.0",
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",
         "@hookform/resolvers": "^4.1.3",
@@ -57,6 +59,25 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@atlaskit/pragmatic-drag-and-drop": {
+      "version": "1.7.7",
+      "resolved": "https://registry.npmjs.org/@atlaskit/pragmatic-drag-and-drop/-/pragmatic-drag-and-drop-1.7.7.tgz",
+      "integrity": "sha512-jX+68AoSTqO/fhCyJDTZ38Ey6/wyL2Iq+J/moanma0YyktpnoHxevjY1UNJHYp0NCburdQDZSL1ZFac1mO1osQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "bind-event-listener": "^3.0.0",
+        "raf-schd": "^4.0.3"
+      }
+    },
+    "node_modules/@atlaskit/pragmatic-drag-and-drop-hitbox": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@atlaskit/pragmatic-drag-and-drop-hitbox/-/pragmatic-drag-and-drop-hitbox-1.1.0.tgz",
+      "integrity": "sha512-JWt6eVp6Br2FPHRM8s0dUIHQk/jFInGP1f3ti5CdtM1Ji5/pt8Akm44wDC063Gv2i5RGseixtbW0z/t6RYtbdg==",
+      "dependencies": {
+        "@atlaskit/pragmatic-drag-and-drop": "^1.6.0",
+        "@babel/runtime": "^7.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2736,6 +2757,11 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "node_modules/bind-event-listener": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bind-event-listener/-/bind-event-listener-3.0.0.tgz",
+      "integrity": "sha512-PJvH288AWQhKs2v9zyfYdPzlPqf5bXbGMmhmUIY9x4dAUGIWgomO771oBQNwJnMQSnUIXhKu6sgzpBRXTlvb8Q=="
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -5328,6 +5354,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/raf-schd": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/raf-schd/-/raf-schd-4.0.3.tgz",
+      "integrity": "sha512-tQkJl2GRWh83ui2DiPTJz9wEiMN20syf+5oKfB03yYP7ioZcJwsIK8FjrtLwH1m7C7e+Tt2yYBlrOpdT+dyeIQ=="
+    },
     "node_modules/react": {
       "version": "19.0.0",
       "resolved": "https://registry.npmjs.org/react/-/react-19.0.0.tgz",
@@ -6128,9 +6159,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.3.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.4.tgz",
-      "integrity": "sha512-BiReIiMS2fyFqbqNT/Qqt4CVITDU9M9vE+DKcVAsB+ZV0wvTKd+3hMbkpxz1b+NmEDMegpVbisKiAZOnvO92Sw==",
+      "version": "6.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.6.tgz",
+      "integrity": "sha512-0msEVHJEScQbhkbVTb/4iHZdJ6SXp/AvxL2sjwYQFfBqleHtnCqv1J3sa9zbWz/6kW1m9Tfzn92vW+kZ1WV6QA==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.25.0",

--- a/soft-skills-front/package.json
+++ b/soft-skills-front/package.json
@@ -10,6 +10,8 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@atlaskit/pragmatic-drag-and-drop": "^1.7.7",
+    "@atlaskit/pragmatic-drag-and-drop-hitbox": "^1.1.0",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",
     "@hookform/resolvers": "^4.1.3",

--- a/soft-skills-front/src/features/learn-to-learn/components/kanban/Board.tsx
+++ b/soft-skills-front/src/features/learn-to-learn/components/kanban/Board.tsx
@@ -1,12 +1,212 @@
 import { Box } from '@mui/material'
 import { ObjectiveBoard } from '../../types/kanban/board.types'
+import { 
+  getDataType,
+  OnDropArgs,
+  DropTargetRecord,
+  ColumnModel,
+  Task
+} from '../../types/kanban/drag-drop.types'
+import {
+  findColumnById,
+  findTaskIndexById,
+  updateColumnTasks,
+  removeTaskFromColumn,
+  insertTaskAtPosition,
+  asCardData,
+  columnIdFrom
+} from '../../utils/kanbanUtils'
 import Column from './Column'
+import { useEffect, useCallback, useState } from 'react'
+import { monitorForElements } from '@atlaskit/pragmatic-drag-and-drop/element/adapter'
+import { getReorderDestinationIndex } from '@atlaskit/pragmatic-drag-and-drop-hitbox/util/get-reorder-destination-index'
+import { reorder } from '@atlaskit/pragmatic-drag-and-drop/reorder'
+import { extractClosestEdge } from '@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge'
 
 interface BoardProps {
   board: ObjectiveBoard
 }
 
+
 const Board = ({ board }: BoardProps) => {
+  const [columnsData, setColumnsData] = useState<ObjectiveBoard>(board)
+
+  const reorderCard = useCallback(
+    (
+      { columnId, startIndex, finishIndex }: 
+      { columnId: string; startIndex: number; finishIndex: number }
+    ) => {
+      const sourceColumn = findColumnById(columnsData.columns, columnId)
+      if (!sourceColumn) return
+
+      const updatedItems = reorder<Task>({
+        list: sourceColumn.tasks,
+        startIndex,
+        finishIndex,
+      })
+
+      const updatedColumns = updateColumnTasks(columnsData.columns, columnId, updatedItems)
+
+      setColumnsData(prev => ({ ...prev, columns: updatedColumns }))
+    },
+    [columnsData]
+  )
+
+  const moveCard = useCallback(
+    (args: {
+      movedCardIndexInSourceColumn: number
+      sourceColumnId: string
+      destinationColumnId: string
+      movedCardIndexInDestinationColumn: number
+    }) => {
+      const { 
+        movedCardIndexInSourceColumn, 
+        sourceColumnId, 
+        destinationColumnId, 
+        movedCardIndexInDestinationColumn 
+      } = args
+
+      const sourceColumn = findColumnById(columnsData.columns, sourceColumnId)
+      const destinationColumn = findColumnById(columnsData.columns, destinationColumnId)
+      if (!sourceColumn || !destinationColumn) return
+
+      const cardToMove = sourceColumn.tasks[movedCardIndexInSourceColumn]
+      if (!cardToMove) return
+
+      const newSourceTasks = removeTaskFromColumn(sourceColumn.tasks, cardToMove.id)
+      const newDestinationTasks = insertTaskAtPosition(destinationColumn.tasks, cardToMove, movedCardIndexInDestinationColumn)
+
+      const updatedColumns = columnsData.columns.map(col => {
+        if (col.id === sourceColumnId) return { ...col, tasks: newSourceTasks }
+        if (col.id === destinationColumnId) return { ...col, tasks: newDestinationTasks }
+
+        return col
+      })
+
+      setColumnsData(prev => ({ ...prev, columns: updatedColumns }))
+    },
+    [columnsData]
+  )
+
+  const getSourceColumnData = useCallback(
+    (location: OnDropArgs['location']): { 
+      sourceColumnId: string
+      sourceColumn: ColumnModel | undefined 
+    } => {
+      const [, sourceColumnRecord] = location.initial.dropTargets
+      const sourceColumnId = columnIdFrom(sourceColumnRecord)
+      const sourceColumn = findColumnById(columnsData.columns, sourceColumnId)
+      
+      return { sourceColumnId, sourceColumn }
+    },
+    [columnsData.columns]
+  )
+
+  const handleColumnDrop = useCallback(
+    (sourceColumnId: string, destinationColumnId: string, draggedCardIndex: number) => {
+      if (sourceColumnId === destinationColumnId) {
+        const sourceColumn = findColumnById(columnsData.columns, sourceColumnId)
+        if (!sourceColumn) return
+
+        const destinationIndex = getReorderDestinationIndex({
+          startIndex: draggedCardIndex,
+          indexOfTarget: sourceColumn.tasks.length - 1,
+          closestEdgeOfTarget: null,
+          axis: 'vertical',
+        })
+
+        reorderCard({ columnId: sourceColumnId, startIndex: draggedCardIndex, finishIndex: destinationIndex })
+      } else {
+        moveCard({
+          movedCardIndexInSourceColumn: draggedCardIndex,
+          sourceColumnId,
+          destinationColumnId,
+          movedCardIndexInDestinationColumn: 0,
+        })
+      }
+    },
+    [columnsData.columns, reorderCard, moveCard]
+  )
+
+  const handleCardDrop = useCallback(
+    (
+      sourceColumnId: string,
+      destinationColumnId: string,
+      draggedCardIndex: number,
+      destinationCardId: string,
+      recordForEdge: DropTargetRecord
+    ) => {
+      const destinationColumn = findColumnById(columnsData.columns, destinationColumnId)
+      if (!destinationColumn) return
+
+      const indexOfTarget = findTaskIndexById(destinationColumn.tasks, destinationCardId)
+      if (indexOfTarget < 0) return
+
+      const closestEdgeOfTarget = extractClosestEdge(asCardData(recordForEdge.data))
+
+      if (sourceColumnId === destinationColumnId) {
+        const destinationIndex = getReorderDestinationIndex({
+          startIndex: draggedCardIndex,
+          indexOfTarget,
+          closestEdgeOfTarget,
+          axis: 'vertical',
+        })
+
+        reorderCard({ columnId: sourceColumnId, startIndex: draggedCardIndex, finishIndex: destinationIndex })
+      } else {
+        const destinationIndex = closestEdgeOfTarget === 'bottom' ? indexOfTarget + 1 : indexOfTarget
+
+        moveCard({
+          movedCardIndexInSourceColumn: draggedCardIndex,
+          sourceColumnId,
+          destinationColumnId,
+          movedCardIndexInDestinationColumn: destinationIndex,
+        })
+      }
+    },
+    [columnsData.columns, reorderCard, moveCard]
+  )
+
+  const handleDrop = useCallback(
+    ({ source, location }: OnDropArgs) => {
+      const targets = location.current.dropTargets
+      if (!targets.length) return
+
+      if (getDataType(source.data) !== 'card') return
+      const dragged = asCardData(source.data)
+      const draggedCardId = dragged.cardId
+
+      const { sourceColumnId, sourceColumn } = getSourceColumnData(location)
+      if (!sourceColumn) return
+
+      const draggedCardIndex = findTaskIndexById(sourceColumn.tasks, draggedCardId)
+      if (draggedCardIndex < 0) return
+
+      // 1 target: dropping into empty column/space
+      if (targets.length === 1) {
+        const destinationColumnId = columnIdFrom(targets[0])
+        handleColumnDrop(sourceColumnId, destinationColumnId, draggedCardIndex)
+        return
+      }
+
+      // 2 targets: dropping on another card
+      if (targets.length === 2) {
+        const [a, b] = targets
+        const aIsCard = getDataType(a.data) === 'card'
+        const cardRecord = aIsCard ? a : b
+        const columnRecord = aIsCard ? b : a
+
+        const destinationColumnId = columnIdFrom(columnRecord)
+        const destinationCardId = asCardData(cardRecord.data).cardId
+
+        handleCardDrop(sourceColumnId, destinationColumnId, draggedCardIndex, destinationCardId, cardRecord)
+      }
+    },
+    [getSourceColumnData, handleColumnDrop, handleCardDrop]
+  )
+
+  useEffect(() => monitorForElements({ onDrop: handleDrop }), [handleDrop])
+
   return (
     <Box
       sx={{
@@ -17,24 +217,24 @@ const Board = ({ board }: BoardProps) => {
         overflow: 'auto',
         minHeight: '400px',
         maxHeight: '600px',
-        '&::-webkit-scrollbar': {
-          height: 6
+        '&::-webkit-scrollbar': { 
+          height: 6 
         },
-        '&::-webkit-scrollbar-track': {
-          backgroundColor: '#f1f1f1',
-          borderRadius: 3
+        '&::-webkit-scrollbar-track': { 
+          backgroundColor: '#f1f1f1', 
+          borderRadius: 3 
         },
-        '&::-webkit-scrollbar-thumb': {
-          backgroundColor: '#c1c1c1',
-          borderRadius: 3,
-          '&:hover': {
-            backgroundColor: '#a8a8a8'
-          }
+        '&::-webkit-scrollbar-thumb': { 
+          backgroundColor: '#c1c1c1', 
+          borderRadius: 3, 
+          '&:hover': { 
+            backgroundColor: '#a8a8a8' 
+          } 
         },
         backgroundColor: '#ffffff',
       }}
     >
-      {board.columns.map((column) => (
+      {columnsData.columns.map(column => (
         <Column key={column.id} column={column} />
       ))}
     </Box>

--- a/soft-skills-front/src/features/learn-to-learn/components/kanban/Column.tsx
+++ b/soft-skills-front/src/features/learn-to-learn/components/kanban/Column.tsx
@@ -1,51 +1,37 @@
 import { Box, Typography, Chip } from '@mui/material'
 import { TaskColumn } from '../../types/kanban/board.types'
+import { ColumnData } from '../../types/kanban/drag-drop.types'
+import { getColumnColor } from '../../utils/columnColors'
 import CardList from './CardList'
+import { useEffect, useRef } from 'react'
+import { dropTargetForElements } from '@atlaskit/pragmatic-drag-and-drop/element/adapter'
 
 interface ColumnProps {
   column: TaskColumn
 }
 
 const Column = ({ column }: ColumnProps) => {
-  const getColumnColor = (columnId: string) => {
-    switch (columnId) {
-      case 'todo':
-        return {
-          bg: '#f8f9fa',
-          border: '#e9ecef',
-          chipColor: 'default' as const
-        }
-      case 'in-progress':
-        return {
-          bg: '#e3f2fd',
-          border: '#bbdefb',
-          chipColor: 'info' as const
-        }
-      case 'done':
-        return {
-          bg: '#e8f5e8',
-          border: '#c8e6c9',
-          chipColor: 'success' as const
-        }
-      case 'paused':
-        return {
-          bg: '#fff3e0',
-          border: '#ffcc02',
-          chipColor: 'warning' as const
-        }
-      default:
-        return {
-          bg: '#f8f9fa',
-          border: '#e9ecef',
-          chipColor: 'default' as const
-        }
-    }
-  }
+  const columnRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const columnEl = columnRef.current
+    if (!columnEl) return
+
+    return dropTargetForElements({
+      element: columnEl,
+      getData: () => ({ 
+        type: 'column', 
+        columnId: column.id 
+      } satisfies ColumnData),
+      getIsSticky: () => true
+    })
+  }, [column.id])
 
   const colors = getColumnColor(column.id)
 
   return (
     <Box
+      ref={columnRef}
       sx={{
         width: 300,
         minWidth: 300,
@@ -104,6 +90,7 @@ const Column = ({ column }: ColumnProps) => {
         sx={{
           flex: 1,
           overflow: 'auto',
+          padding: '8px 0',
           '&::-webkit-scrollbar': {
             width: 6
           },

--- a/soft-skills-front/src/features/learn-to-learn/components/kanban/DropIndicator.tsx
+++ b/soft-skills-front/src/features/learn-to-learn/components/kanban/DropIndicator.tsx
@@ -1,0 +1,36 @@
+import { Box } from '@mui/material'
+
+interface DropIndicatorProps {
+  edge: 'top' | 'bottom'
+  gap?: string
+}
+
+const DropIndicator = ({ edge, gap = '8px' }: DropIndicatorProps) => {
+  const getIndicatorStyle = () => {
+    const baseStyle = {
+      position: 'absolute' as const,
+      left: 0,
+      right: 0,
+      height: '2px',
+      backgroundColor: '#1976d2',
+      borderRadius: '1px',
+      pointerEvents: 'none' as const,
+    }
+
+    if (edge === 'top') {
+      return {
+        ...baseStyle,
+        top: `-${gap}`,
+      }
+    }
+
+    return {
+      ...baseStyle,
+      bottom: `-${gap}`,
+    }
+  }
+
+  return <Box sx={getIndicatorStyle()} />
+}
+
+export default DropIndicator

--- a/soft-skills-front/src/features/learn-to-learn/components/kanban/TaskCard.tsx
+++ b/soft-skills-front/src/features/learn-to-learn/components/kanban/TaskCard.tsx
@@ -1,29 +1,92 @@
 import { Card, CardContent, Typography, Chip, Box } from '@mui/material'
 import { CalendarToday, Flag } from '@mui/icons-material'
 import { SubTask } from '../../types/kanban/board.types'
+import { CardData } from '../../types/kanban/drag-drop.types'
 import { getPriorityColor } from '../../utils/objectiveUtils'
 import { formatDateString } from '../../../../utils/formatDate'
+import { useEffect, useRef, useState } from 'react'
+import { 
+  draggable,
+  dropTargetForElements
+} from '@atlaskit/pragmatic-drag-and-drop/element/adapter'
+import { combine } from '@atlaskit/pragmatic-drag-and-drop/combine'
+import { 
+  attachClosestEdge,
+  extractClosestEdge
+} from '@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge'
+import DropIndicator from './DropIndicator'
 
 interface TaskCardProps {
   task: SubTask
 }
 
 const TaskCard = ({ task }: TaskCardProps) => {
+  const cardRef = useRef<HTMLDivElement>(null)
+  const [closestEdge, setClosestEdge] = useState<'top' | 'bottom' | 'left' | 'right' | null>(null)
+
+  useEffect(() => {
+    const cardEl = cardRef.current
+    if (!cardEl) return
+
+    return combine(
+      draggable({
+        element: cardEl,
+        getInitialData: () => ({ 
+          type: 'card', 
+          cardId: task.id, 
+          columnId: '', 
+          index: 0 
+        } satisfies CardData)
+      }),
+      dropTargetForElements({
+        element: cardEl,
+        getData: ({ input, element }) => {
+          const data = { type: 'card', cardId: task.id }
+          return attachClosestEdge(data, {
+            input,
+            element,
+            allowedEdges: ['top', 'bottom']
+          })
+        },
+        getIsSticky: () => true,
+        onDragEnter: (args) => {
+          const edge = extractClosestEdge(args.self.data)
+          setClosestEdge(edge)
+        },
+        onDrag: (args) => {
+          const edge = extractClosestEdge(args.self.data)
+          setClosestEdge(edge)
+        },
+        onDragLeave: () => {
+          setClosestEdge(null)
+        },
+        onDrop: () => {
+          setClosestEdge(null)
+        }
+      })
+    )
+  }, [task.id])
 
   return (
     <Card
+      ref={cardRef}
       elevation={0}
       sx={{
         mb: 2,
-        cursor: 'pointer',
+        cursor: 'grab',
         transition: 'all 0.2s ease-in-out',
         border: '1px solid #e0e0e0',
+        position: 'relative',
+        overflow: 'visible',
         '&:hover': {
           borderColor: '#bdbdbd',
           transform: 'translateY(-1px)'
         },
         '&:last-child': {
           mb: 0
+        },
+        '&:active': {
+          cursor: 'grabbing'
         }
       }}
     >
@@ -110,6 +173,9 @@ const TaskCard = ({ task }: TaskCardProps) => {
           )}
         </Box>
       </CardContent>
+      {closestEdge && (closestEdge === 'top' || closestEdge === 'bottom') && (
+        <DropIndicator edge={closestEdge} gap="4px" />
+      )}
     </Card>
   )
 }

--- a/soft-skills-front/src/features/learn-to-learn/hooks/useKanbanTasks.ts
+++ b/soft-skills-front/src/features/learn-to-learn/hooks/useKanbanTasks.ts
@@ -8,17 +8,11 @@ export const useKanbanTasks = (objectiveId: string | null, objectiveTitle: strin
     queryFn: async () => {
       if (!objectiveId) throw new Error('Objective ID is required')
       
-      try {
-        const apiResponse = await fetchKanbanTasks(objectiveId)
-        console.log('Kanban API Response:', apiResponse)
-        return transformKanbanApiResponse(apiResponse, objectiveId, objectiveTitle)
-      } catch (error) {
-        console.error('Kanban fetch error:', error)
-        throw error
-      }
+      const apiResponse = await fetchKanbanTasks(objectiveId)
+      return transformKanbanApiResponse(apiResponse, objectiveId, objectiveTitle)
     },
     enabled: !!objectiveId,
-    staleTime: 5 * 60 * 1000, // 5 minutes
-    gcTime: 10 * 60 * 1000, // 10 minutes
+    staleTime: 5 * 60 * 1000, 
+    gcTime: 10 * 60 * 1000, 
   })
 }

--- a/soft-skills-front/src/features/learn-to-learn/types/kanban/drag-drop.types.ts
+++ b/soft-skills-front/src/features/learn-to-learn/types/kanban/drag-drop.types.ts
@@ -1,0 +1,54 @@
+
+export type CardData = { 
+  type: 'card'
+  cardId: string
+  columnId: string
+  index: number
+}
+
+export type ColumnData = { 
+  type: 'column'
+  columnId: string
+}
+
+export const isCardData = (data: unknown): data is CardData => {
+  return (
+    typeof data === 'object' &&
+    data !== null &&
+    'type' in data &&
+    (data as Record<string, unknown>).type === 'card' &&
+    'cardId' in data &&
+    'columnId' in data &&
+    'index' in data
+  )
+}
+
+export const isColumnData = (data: unknown): data is ColumnData => {
+  return (
+    typeof data === 'object' &&
+    data !== null &&
+    'type' in data &&
+    (data as Record<string, unknown>).type === 'column' &&
+    'columnId' in data
+  )
+}
+
+
+export const getDataType = (x: unknown): string | undefined => {
+  if (typeof x !== 'object' || x === null) return undefined
+
+  if (!('type' in x)) return undefined
+
+  const t = (x as { type?: unknown }).type
+  
+  return typeof t === 'string' ? t : undefined
+}
+
+// Pragmatic Drag and Drop related types
+export type MonitorOptions = Parameters<typeof import('@atlaskit/pragmatic-drag-and-drop/element/adapter').monitorForElements>[0]
+export type OnDropArgs = Parameters<NonNullable<MonitorOptions['onDrop']>>[0]
+export type DropTargetRecord = OnDropArgs['location']['current']['dropTargets'][number]
+
+// Board model types
+export type ColumnModel = import('./board.types').ObjectiveBoard['columns'][number]
+export type Task = ColumnModel['tasks'][number]

--- a/soft-skills-front/src/features/learn-to-learn/utils/columnColors.ts
+++ b/soft-skills-front/src/features/learn-to-learn/utils/columnColors.ts
@@ -1,0 +1,53 @@
+export type ColumnColorScheme = {
+  bg: string
+  border: string
+  chipColor: 'default' | 'info' | 'success' | 'warning'
+}
+
+const TODO_COLORS: ColumnColorScheme = {
+  bg: '#f8f9fa',
+  border: '#e9ecef',
+  chipColor: 'default'
+}
+
+const IN_PROGRESS_COLORS: ColumnColorScheme = {
+  bg: '#e3f2fd',
+  border: '#bbdefb',
+  chipColor: 'info'
+}
+
+const DONE_COLORS: ColumnColorScheme = {
+  bg: '#e8f5e8',
+  border: '#c8e6c9',
+  chipColor: 'success'
+}
+
+const PAUSED_COLORS: ColumnColorScheme = {
+  bg: '#fff3e0',
+  border: '#ffcc02',
+  chipColor: 'warning'
+}
+
+const DEFAULT_COLORS: ColumnColorScheme = {
+  bg: '#f8f9fa',
+  border: '#e9ecef',
+  chipColor: 'default'
+}
+
+/**
+ * Gets the color scheme for a column based on its ID
+ */
+export const getColumnColor = (columnId: string): ColumnColorScheme => {
+  switch (columnId) {
+    case 'todo':
+      return TODO_COLORS
+    case 'in-progress':
+      return IN_PROGRESS_COLORS
+    case 'done':
+      return DONE_COLORS
+    case 'paused':
+      return PAUSED_COLORS
+    default:
+      return DEFAULT_COLORS
+  }
+}

--- a/soft-skills-front/src/features/learn-to-learn/utils/kanbanUtils.ts
+++ b/soft-skills-front/src/features/learn-to-learn/utils/kanbanUtils.ts
@@ -1,6 +1,7 @@
 import { KanbanApiResponse, TaskItem, TaskStatus } from '../types/kanban/task.api'
 import { Priority } from '../types/common.enums'
 import { ObjectiveBoard, SubTask, TaskColumn } from '../types/kanban/board.types'
+import { CardData, ColumnData, ColumnModel, Task, DropTargetRecord } from '../types/kanban/drag-drop.types'
 import { normalizeDate } from './dateUtils'
 
 /**
@@ -37,7 +38,6 @@ function mapApiPriorityToComponentPriority(apiPriority: Priority): 'LOW' | 'MEDI
  * Maps API status values to component status values
  */
 function mapApiStatusToComponentStatus(apiStatus: TaskStatus): 'TODO' | 'IN_PROGRESS' | 'PAUSED' | 'DONE' {
-  console.log('API Status:', apiStatus)
   switch (apiStatus) {
     case TaskStatus.NOT_STARTED:
       return 'TODO'
@@ -88,3 +88,46 @@ export function transformKanbanApiResponse(
     columns
   }
 }
+
+/**
+ * Finds a column by its ID
+ */
+export const findColumnById = (columns: ColumnModel[], columnId: string): ColumnModel | undefined =>
+  columns.find(col => col.id === columnId)
+
+/**
+ * Finds the index of a task by its ID
+ */
+export const findTaskIndexById = (tasks: Task[], taskId: string): number =>
+  tasks.findIndex(task => task.id === taskId)
+
+/**
+ * Updates tasks for a specific column
+ */
+export const updateColumnTasks = (columns: ColumnModel[], columnId: string, newTasks: Task[]): ColumnModel[] =>
+  columns.map(col => (col.id === columnId ? { ...col, tasks: newTasks } : col))
+
+/**
+ * Removes a task from a column by task ID
+ */
+export const removeTaskFromColumn = (tasks: Task[], taskId: string): Task[] =>
+  tasks.filter(task => task.id !== taskId)
+
+/**
+ * Inserts a task at a specific position in a task list
+ */
+export const insertTaskAtPosition = (tasks: Task[], task: Task, position: number): Task[] => {
+  const newTasks = tasks.slice()
+  newTasks.splice(Math.max(0, Math.min(position, newTasks.length)), 0, task)
+  return newTasks
+}
+
+/**
+ * Type-safe casting helper for CardData
+ */
+export const asCardData = (x: unknown): CardData => x as CardData
+
+/**
+ * Extracts column ID from a drop target record
+ */
+export const columnIdFrom = (rec: DropTargetRecord): string => (rec.data as CardData | ColumnData).columnId


### PR DESCRIPTION
What:
- Added drag-and-drop support in Board using pragmatic-drag-and-drop
- Introduced typed helpers (getDataType, asCardData, columnIdFrom) to remove `any`
- Split common board utilities into kanbanUtils for reuse
- Updated imports in Board.tsx to use centralized types and utils
- Ensured type safety across Card and Column drop/drag operations

Why:
- Enable card reordering and moving between columns with Pdnd
- Improve maintainability and readability by removing `any`
- Provide consistent typing for board, column, and card data