### PR TITLE
Normalize datetime serialization to UTC without microseconds

### DIFF
--- a/soft-skills-back/router/roadmap.py
+++ b/soft-skills-back/router/roadmap.py
@@ -62,7 +62,7 @@ def get_user_roadmaps(
 def get_public_roadmaps(
     offset: int = Query(0, ge=0, description="Number of items to skip before starting to collect the result set"),
     limit: int = Query(10, ge=10, le=50,  description="Maximum number of items to retrieve (between 10 and 50)"),
-    token_data: TokenData = Depends(decode_jwt_token),
+    _: TokenData = Depends(decode_jwt_token),
 ):
     try:
         return roadmap_service.get_public_roadmaps(offset, limit)
@@ -77,7 +77,7 @@ def get_public_roadmaps(
 )
 def get_roadmap(
     id: str,
-    token_data: TokenData = Depends(decode_jwt_token),
+    _: TokenData = Depends(decode_jwt_token),
 ):
     try:
         roadmap = roadmap_service.get_roadmap_by_id(id)
@@ -97,7 +97,7 @@ def get_roadmap(
 async def update_roadmap(
     id: str,
     update_data: RoadmapUpdate,
-    token_data: TokenData = Depends(decode_jwt_token),
+    _: TokenData = Depends(decode_jwt_token),
 ):
     try:
         success = roadmap_service.update_roadmap(id, update_data.model_dump(mode="json", exclude_none=True))
@@ -119,7 +119,7 @@ async def update_roadmap(
 )
 def delete_roadmap(
     id: str,
-    token_data: TokenData = Depends(decode_jwt_token),
+    _: TokenData = Depends(decode_jwt_token),
 ):
     try:
         roadmap_service.delete_roadmap(id)

--- a/soft-skills-back/schema/learning_goal.py
+++ b/soft-skills-back/schema/learning_goal.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from typing import List, TypeVar
 
 from model.learning_goal import LearningGoalBase
-from pydantic import UUID4
+from pydantic import UUID4, field_serializer
 from schema.base import BaseResponse, PaginatedResponse
 from schema.objective import ObjectiveSummary
 from sqlmodel import Field, SQLModel
@@ -12,6 +12,7 @@ from utils.payloads import (LEARNING_GOAL_CREATE_EXAMPLE,
                             LEARNING_GOAL_READ_EXAMPLE,
                             LEARNING_GOAL_WITH_PROGRESS_READ_EXAMPLE,
                             LEARNING_GOAL_UPDATE_EXAMPLE)
+from utils.serializers import serialize_datetime_without_microseconds
 
 T = TypeVar("T")
 class LearningGoalCreate(LearningGoalBase):
@@ -24,6 +25,14 @@ class LearningGoalReadBase(LearningGoalBase):
   updated_at: datetime | None = Field(default=None)
   started_at: datetime | None = Field(default=None)
   completed_at: datetime | None = Field(default=None)
+
+  @field_serializer("started_at", "completed_at", "created_at", "updated_at", when_used="json")
+  def serialize_datetime_fields(self, v: datetime | None) -> str | None:
+      return serialize_datetime_without_microseconds(v)
+
+  model_config = {
+      "from_attributes": True
+  }
 
 class LearningGoalRead(LearningGoalReadBase):
   model_config={"json_schema_extra": {"example": LEARNING_GOAL_READ_EXAMPLE}}

--- a/soft-skills-back/schema/task.py
+++ b/soft-skills-back/schema/task.py
@@ -3,11 +3,12 @@ from datetime import datetime
 from enums.common import Priority, Status
 from enums.task import TaskType
 from model.task import TaskBase
-from pydantic import UUID4
+from pydantic import UUID4, field_serializer
 from schema.base import BaseResponse, PaginatedResponse
 from sqlmodel import Field, SQLModel
 from utils.payloads import (TASK_CREATE_EXAMPLE, TASK_READ_EXAMPLE,
                             TASK_UPDATE_EXAMPLE)
+from utils.serializers import serialize_datetime_without_microseconds
 
 
 class TaskCreate(TaskBase):
@@ -18,7 +19,14 @@ class TaskRead(TaskBase):
     started_at: datetime | None
     completed_at: datetime | None
 
-    model_config={"json_schema_extra": {"example": TASK_READ_EXAMPLE}}
+    @field_serializer("started_at", "completed_at", when_used="json")
+    def serialize_datetime_fields(self, v: datetime | None) -> str | None:
+        return serialize_datetime_without_microseconds(v)
+
+    model_config={
+        "json_schema_extra": {"example": TASK_READ_EXAMPLE},
+        "from_attributes": True
+    }
 
 class TaskSummary(SQLModel):
     task_id: UUID4
@@ -26,6 +34,14 @@ class TaskSummary(SQLModel):
     status: Status
     priority: Priority
     due_date: datetime | None
+
+    @field_serializer("due_date", when_used="json")
+    def serialize_due_date(self, v: datetime | None) -> str | None:
+        return serialize_datetime_without_microseconds(v)
+
+    model_config = {
+        "from_attributes": True
+    }
 
 
 class TaskUpdate(SQLModel):
@@ -43,9 +59,14 @@ class TaskUpdate(SQLModel):
     is_optional: bool | None = Field(default=None, description="Indicates whether the task is optional")
     estimated_time: float | None = Field(default=None, description="Time that will take to complete the task")
 
+    @field_serializer("due_date", when_used="json")
+    def serialize_due_date(self, v: datetime | None) -> str | None:
+        return serialize_datetime_without_microseconds(v)
+
     model_config={
         "json_schema_extra": {"example": TASK_UPDATE_EXAMPLE},
-        "extra": "forbid"
+        "extra": "forbid",
+        "from_attributes": True
     }
 
 class TaskResponse(BaseResponse[TaskRead]):

--- a/soft-skills-back/utils/serializers.py
+++ b/soft-skills-back/utils/serializers.py
@@ -1,0 +1,29 @@
+"""
+Utility functions for data serialization
+"""
+from datetime import datetime, timezone
+
+
+def serialize_datetime_without_microseconds(v: datetime | None) -> str | None:
+    """
+    Serialize datetime to ISO format without microseconds and with UTC timezone.
+    
+    Args:
+        v: datetime object or None
+        
+    Returns:
+        ISO formatted string with 'Z' suffix for UTC, or None if input is None
+        
+    Example:
+        >>> from datetime import datetime, timezone
+        >>> dt = datetime(2023, 1, 1, 12, 30, 45, 123456, timezone.utc)
+        >>> serialize_datetime_without_microseconds(dt)
+        '2023-01-01T12:30:45Z'
+    """
+    if v is None:
+        return None
+    
+    if v.tzinfo is None:
+        v = v.replace(tzinfo=timezone.utc)
+    
+    return v.replace(microsecond=0).isoformat().replace("+00:00", "Z")


### PR DESCRIPTION
What:
- Added field serializers in read models (e.g. LearningGoalReadBase, ObjectiveRead) to ensure datetime fields are serialized in ISO 8601 format without microseconds
- Normalized naive datetimes to UTC and converted "+00:00" offsets to "Z"

Why:
- Improves consistency across API responses
- Removes noisy microseconds for cleaner, human-friendly output
- Ensures all timestamps are standardized in UTC for clients