### PR TITLE
feat(roadmaps): add Explore view for browsing public roadmaps

### DIFF
--- a/soft-skills-back/mongo_service/roadmap.py
+++ b/soft-skills-back/mongo_service/roadmap.py
@@ -1,6 +1,8 @@
-from typing import Dict, List
+from typing import Dict, Optional
 from bson import ObjectId
 from datetime import datetime, timezone
+from uuid import UUID
+import re
 
 from enums.roadmap import Visibility
 from utils.mongodb import MongoDB
@@ -8,6 +10,8 @@ from utils.logger import logger_config
 from utils.errors import APIException, Missing, handle_db_error
 from nosql_models.roadmap import Roadmap
 from nosql_schema.roadmap import to_roadmap_model, to_roadmap_summary_model, PaginatedRoadmapsResponse
+from service.user import UserService
+from sqlmodel import Session
 
 logger = logger_config(__name__)
 
@@ -17,6 +21,7 @@ class RoadmapMongoService:
         self.mongodb = MongoDB()
         self.mongodb.set_db("learning_roadmap") 
         self.collection_name = "roadmaps"
+        self.user_service = UserService()
 
     def get_roadmap_by_id(self, roadmap_id: str) -> Roadmap:
         try:
@@ -59,9 +64,52 @@ class RoadmapMongoService:
         except Exception as err:
             handle_db_error(err, "get_user_roadmaps")
       
-    def get_public_roadmaps(self, offset: int, limit: int) -> PaginatedRoadmapsResponse:
+    def _apply_steps_filtering(self, documents: list, steps_min: Optional[int], steps_max: Optional[int]) -> list:
+        """Apply steps filtering to documents after converting to summary models"""
+        filtered_summaries = []
+        for doc in documents:
+            summary = to_roadmap_summary_model(doc)
+            
+            if steps_min is not None and summary.steps_count < steps_min:
+                continue
+            if steps_max is not None and summary.steps_count > steps_max:
+                continue
+                
+            filtered_summaries.append(summary)
+        
+        return filtered_summaries
+
+    def get_public_roadmaps(
+        self, 
+        offset: int, 
+        limit: int,
+        title: Optional[str] = None,
+        description: Optional[str] = None,
+        created_at_from: Optional[datetime] = None,
+        created_at_to: Optional[datetime] = None,
+        steps_min: Optional[int] = None,
+        steps_max: Optional[int] = None,
+        username: Optional[str] = None
+    ) -> PaginatedRoadmapsResponse:
         try:
-            filter_query = { "visibility": "public" }
+            filter_query = {"visibility": "public"}
+            
+            if title:
+                filter_query["title"] = {"$regex": re.escape(title), "$options": "i"}
+            
+            if description:
+                filter_query["description"] = {"$regex": re.escape(description), "$options": "i"}
+            
+            if created_at_from or created_at_to:
+                date_filter = {}
+                if created_at_from:
+                    date_filter["$gte"] = created_at_from.isoformat()
+                if created_at_to:
+                    date_filter["$lte"] = created_at_to.isoformat()
+                filter_query["created_at"] = date_filter
+            
+            if username:
+                filter_query["username"] = {"$regex": re.escape(username), "$options": "i"}
 
             total = self.mongodb.count_documents(self.collection_name, filter_query)
 
@@ -73,18 +121,43 @@ class RoadmapMongoService:
                 sort=[("created_at", -1)],
             )
 
-            summaries = [to_roadmap_summary_model(doc) for doc in documents]
+            summaries = []
+            for doc in documents:
+                summary = to_roadmap_summary_model(doc)
+                
+                if steps_min is not None and summary.steps_count < steps_min:
+                    continue
+                if steps_max is not None and summary.steps_count > steps_max:
+                    continue
+                    
+                summaries.append(summary)
+
+            if steps_min is not None or steps_max is not None:
+                filtered_documents = self.mongodb.find_many(
+                    self.collection_name,
+                    filter_query,
+                    sort=[("created_at", -1)],
+                )
+                
+                filtered_summaries = self._apply_steps_filtering(filtered_documents, steps_min, steps_max)
+                total = len(filtered_summaries)
+                
+                summaries = filtered_summaries[offset:offset + limit]
 
             return PaginatedRoadmapsResponse(data=summaries, total=total)
 
         except Exception as err:
             handle_db_error(err, "get_public_roadmaps")
 
-    def add_roadmap(self, roadmap_data: Dict, user_id: str) -> Dict:
+    def add_roadmap(self, roadmap_data: Dict, user_id: str, session: Session) -> Dict:
         try:
+            user = self.user_service.get_user(UUID(user_id), session)
+            username = user.username
+            
             current_time = datetime.now(timezone.utc).isoformat()
             roadmap_data.update({
                 "user_id": user_id,
+                "username": username,
                 "visibility": Visibility.private,
                 "created_at": current_time,
                 "updated_at": current_time,

--- a/soft-skills-back/nosql_models/roadmap.py
+++ b/soft-skills-back/nosql_models/roadmap.py
@@ -74,6 +74,7 @@ class Roadmap(BaseModel):
     objectives: List[Objective]
     layout: Optional[Layout] = None
     user_id: str
+    username: str
     created_at: Optional[str]
     updated_at: Optional[str]
     visibility: Visibility = Visibility.private
@@ -88,6 +89,7 @@ class Roadmap(BaseModel):
 class RoadmapSummary(BaseModel):
     roadmap_id: str
     title: str
+    username: str
     description: Optional[str] = None
     created_at: Optional[str] = None
     steps_count: int

--- a/soft-skills-back/nosql_schema/roadmap.py
+++ b/soft-skills-back/nosql_schema/roadmap.py
@@ -52,6 +52,7 @@ def to_roadmap_summary_model(doc: dict) -> RoadmapSummary:
     return RoadmapSummary(
         roadmap_id=str(doc["_id"]),
         title=doc.get("title", ""),
+        username=doc.get("username", ""),
         description=doc.get("description"),
         created_at=doc.get("created_at"),  
         steps_count=total_tasks,

--- a/soft-skills-back/service/user.py
+++ b/soft-skills-back/service/user.py
@@ -73,6 +73,21 @@ class UserService:
         except Exception as err:
             handle_db_error(err, "get_user", error_type="query")
 
+    def get_user_by_username(self, username: str, session: Session) -> User:
+        try:
+            query = select(User).where(User.username == username)
+            user = session.exec(query).first()
+
+            if not user:
+                raise Missing("User not found")
+            return user
+        
+        except APIException as api_error:
+            raise api_error
+
+        except Exception as err:
+            handle_db_error(err, "get_user_by_username", error_type="query")
+
     def update_user(self, user_id: UUID, user: UserUpdate, session: Session) -> User:
         try:
             existing_user = self.get_user(user_id, session)

--- a/soft-skills-front/src/features/learn-to-learn/api/Roadmaps.ts
+++ b/soft-skills-front/src/features/learn-to-learn/api/Roadmaps.ts
@@ -1,6 +1,6 @@
 import { api } from "../../../config/api"
 import { fetchWithAuth } from "../../../utils/fetchWithAuth"
-import { CreateRoadmapPayload, FetchRoadmapsSummaryResponse } from "../types/roadmap/roadmap.api"
+import { CreateRoadmapPayload, FetchRoadmapsSummaryResponse, PublicRoadmapsParams } from "../types/roadmap/roadmap.api"
 import { Roadmap } from "../types/roadmap/roadmap.models"
 import { normalizeLayoutNodes } from "../utils/roadmap/roadmapSerializers"
 import snakecaseKeys from 'snakecase-keys'
@@ -16,10 +16,27 @@ export async function getUserRoadmaps(
 }
 
 export async function getPublicRoadmaps(
-  offset: number, 
-  limit: number
+  params: PublicRoadmapsParams = {}
 ): Promise<FetchRoadmapsSummaryResponse> {
-  const url = `${api.roadmap.getPublic}?offset=${offset}&limit=${limit}`
+  const { 
+    search, 
+    authorId, 
+    minSteps, 
+    maxSteps, 
+    offset = 0, 
+    limit = 10 
+  } = params
+
+  const searchParams = new URLSearchParams()
+  searchParams.append('offset', offset.toString())
+  searchParams.append('limit', limit.toString())
+  
+  if (search) searchParams.append('title', search)
+  if (authorId) searchParams.append('username', authorId)
+  if (minSteps !== undefined) searchParams.append('steps_min', minSteps.toString())
+  if (maxSteps !== undefined) searchParams.append('steps_max', maxSteps.toString())
+
+  const url = `${api.roadmap.getPublic}?${searchParams.toString()}`
 
   const response = await fetchWithAuth(url)
   return response

--- a/soft-skills-front/src/features/learn-to-learn/components/roadmap/RoadmapCard.tsx
+++ b/soft-skills-front/src/features/learn-to-learn/components/roadmap/RoadmapCard.tsx
@@ -6,26 +6,87 @@ import {
   CardHeader,
   CardContent,
   CardActions,
-  IconButton
+  IconButton,
+  Chip,
+  SxProps,
+  Theme
 } from '@mui/material'
 import DeleteIcon from '@mui/icons-material/Delete'
 import OpenInNewIcon from '@mui/icons-material/OpenInNew'
 import PublicIcon from '@mui/icons-material/Public'
 import LockIcon from '@mui/icons-material/Lock'
+import PersonIcon from '@mui/icons-material/Person'
 import { useState } from 'react'
 import { RoadmapSummary } from '../../types/roadmap/roadmap.models'
 import { formatDateString } from '../../../../utils/formatDate'
 
-interface GoalCardProps {
+interface RoadmapCardProps {
   roadmapSummary: RoadmapSummary
   onDeleteClick?: () => void
   onViewClick?: () => void
+  mode?: 'private' | 'public'
 }
 
-const RoadmapCard = ({ roadmapSummary, onDeleteClick, onViewClick }: GoalCardProps) => {
+const getConditionalStyles = (isPublicMode: boolean): {
+  title: SxProps<Theme>
+  description: SxProps<Theme>
+  cardHeader: SxProps<Theme>
+  cardContent: SxProps<Theme>
+  cardActions: SxProps<Theme>
+} => ({
+  title: isPublicMode ? {
+    display: '-webkit-box',
+    WebkitLineClamp: 2,
+    WebkitBoxOrient: 'vertical',
+    overflow: 'hidden',
+    lineHeight: 1.3,
+    minHeight: '2.6em'
+  } : {},
+  
+  description: isPublicMode ? {
+    display: '-webkit-box',
+    WebkitLineClamp: 3,
+    WebkitBoxOrient: 'vertical',
+    overflow: 'hidden',
+    mb: 2,
+    minHeight: '3.6em',
+    lineHeight: 1.4
+  } : { mb: 2 },
+  
+  cardHeader: {
+    pb: isPublicMode ? 1 : 'default'
+  },
+  
+  cardContent: {
+    pt: isPublicMode ? 0 : 'default',
+    pb: 2
+  },
+  
+  cardActions: {
+    justifyContent: "center",
+    pt: isPublicMode ? 0 : 'default'
+  }
+})
+
+const getStepsText = (stepsCount: number): string => {
+  return `${stepsCount} ${stepsCount === 1 ? 'step' : 'steps'}`
+}
+
+const getConditionalContent = (isPublicMode: boolean, roadmapSummary: RoadmapSummary) => ({
+  descriptionText: roadmapSummary.description || (isPublicMode ? 'No description available' : ''),
+  dateFormat: isPublicMode ? "Created" : "Created:",
+  showAuthor: isPublicMode,
+  showVisibilityIcon: !isPublicMode,
+  showDeleteAction: !isPublicMode
+})
+
+const RoadmapCard = ({ roadmapSummary, onDeleteClick, onViewClick, mode = 'private' }: RoadmapCardProps) => {
   const [hovered, setHovered] = useState(false)
 
   const stepsCount = roadmapSummary.stepsCount || 0
+  const isPublicMode = mode === 'public'
+  const styles = getConditionalStyles(isPublicMode)
+  const content = getConditionalContent(isPublicMode, roadmapSummary)
 
   return (
     <Card 
@@ -41,59 +102,96 @@ const RoadmapCard = ({ roadmapSummary, onDeleteClick, onViewClick }: GoalCardPro
         boxShadow: "none",
         minHeight: 300,
         width: '100%',
-        height: '100%', 
+        height: '100%',
+        cursor: 'default',
       }}
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
-      >
+    >
       <CardHeader
         title={
-          <Stack direction="row" alignItems="center" spacing={1}>
-            <Typography variant="h6" component="span">
+          isPublicMode ? (
+            <Typography 
+              variant="h6" 
+              component="span"
+              sx={styles.title}
+            >
               {roadmapSummary.title}
             </Typography>
-            {roadmapSummary.visibility === 'public' ? (
-              <PublicIcon sx={{ color: 'text.secondary', fontSize: '1.2rem' }} />
-            ) : (
-              <LockIcon sx={{ color: 'text.secondary', fontSize: '1.2rem' }} />
-            )}
-          </Stack>
+          ) : (
+            <Stack direction="row" alignItems="center" spacing={1}>
+              <Typography variant="h6" component="span">
+                {roadmapSummary.title}
+              </Typography>
+              {content.showVisibilityIcon && (
+                roadmapSummary.visibility === 'public' ? (
+                  <PublicIcon sx={{ color: 'text.secondary', fontSize: '1.2rem' }} />
+                ) : (
+                  <LockIcon sx={{ color: 'text.secondary', fontSize: '1.2rem' }} />
+                )
+              )}
+            </Stack>
+          )
         }
         action={
-          hovered && (
+          content.showDeleteAction && hovered && (
             <IconButton aria-label='delete' onClick={onDeleteClick}>
               <DeleteIcon/>
             </IconButton>
           )
         }
+        sx={styles.cardHeader}
       />
-      <CardContent>
-        <Typography variant='body2' color="text.secondary" mb={2}>
-          {roadmapSummary.description}
+      <CardContent sx={styles.cardContent}>
+        <Typography 
+          variant='body2' 
+          color="text.secondary" 
+          sx={styles.description}
+        >
+          {content.descriptionText}
         </Typography>
-        <Stack direction="row" justifyContent="space-between" alignItems="center">
+
+        {content.showAuthor && (
+          <Stack direction="row" alignItems="center" spacing={1} mb={2}>
+            <PersonIcon sx={{ fontSize: '1rem', color: 'text.secondary' }} />
+            <Typography variant="body2" color="text.secondary" fontWeight="500">
+              {roadmapSummary.username}
+            </Typography>
+          </Stack>
+        )}
+
+        <Stack direction="row" justifyContent="space-between" alignItems="center" mb={isPublicMode ? 2 : 0}>
           <Typography variant="caption" color="text.secondary">
-            {
-              formatDateString(roadmapSummary.createdAt, "Not defined", "Created:")
-            }
+            {formatDateString(roadmapSummary.createdAt, "Not defined", content.dateFormat)}
           </Typography>
 
-          <Typography variant="caption" color="text.secondary">
-            {stepsCount} {stepsCount === 1 ? 'step' : 'steps'}
-          </Typography>
-      </Stack>
+          {isPublicMode ? (
+            <Chip 
+              label={getStepsText(stepsCount)}
+              size="small"
+              variant="outlined"
+              sx={{ 
+                fontSize: '0.75rem',
+                height: '24px'
+              }}
+            />
+          ) : (
+            <Typography variant="caption" color="text.secondary">
+              {getStepsText(stepsCount)}
+            </Typography>
+          )}
+        </Stack>
       </CardContent>
 
-      <CardActions 
-        sx={{ 
-          justifyContent: "center"
-        }}
-      >
+      <CardActions sx={styles.cardActions}>
         <Button
           fullWidth
           variant="contained"
           color="secondary"
-          onClick={onViewClick}
+          onClick={isPublicMode ? (e) => {
+            e.stopPropagation()
+            onViewClick?.()
+          } : onViewClick}
           endIcon={<OpenInNewIcon />}
           sx={{
             fontWeight: 500,

--- a/soft-skills-front/src/features/learn-to-learn/components/ui/ActiveFilters.tsx
+++ b/soft-skills-front/src/features/learn-to-learn/components/ui/ActiveFilters.tsx
@@ -1,0 +1,121 @@
+import { Box, Typography, Chip, Button } from '@mui/material'
+import { FilterOption, FilterType } from '../../types/ui/filter.types'
+
+export interface SelectedFilters {
+  [key: string]: string[]
+}
+
+interface ActiveFiltersProps {
+  appliedFilters: SelectedFilters
+  filterOptions: FilterOption[]
+  onRemoveFilter: (filterKey: string) => void
+  onClearAllFilters: () => void
+}
+
+const ActiveFilters = ({
+  appliedFilters,
+  filterOptions,
+  onRemoveFilter,
+  onClearAllFilters
+}: ActiveFiltersProps) => {
+  const getFilterChips = () => {
+    const chipLabelGenerators: Record<FilterType, (option: FilterOption, value: string) => string> = {
+      text: (option: FilterOption, value: string) => `${option.label}: ${value}`,
+      
+      range: (option: FilterOption, value: string) => {
+        const [min, max] = value.split('-')
+        const minText = min || ''
+        const maxText = max || ''
+        
+        if (minText && maxText) return `${option.label}: ${minText}-${maxText}`
+        if (minText) return `${option.label}: ≥${minText}`
+        if (maxText) return `${option.label}: ≤${maxText}`
+        return ''
+      },
+      
+      select: (option: FilterOption, value: string) => {
+        const optionValue = option.values?.find(v => v.value === value)
+        return `${option.label}: ${optionValue?.label || value}`
+      },
+      
+      checkbox: (option: FilterOption, value: string) => {
+        const optionValue = option.values?.find(v => v.value === value)
+        return `${option.label}: ${optionValue?.label || value}`
+      }
+    }
+
+    return filterOptions.flatMap(option => {
+      const values = appliedFilters[option.key] || []
+      const labelGenerator = chipLabelGenerators[option.type]
+      
+      return values
+        .map(value => labelGenerator(option, value))
+        .filter(label => label)
+        .map((label, index) => ({
+          key: `${option.key}-${values[index]}`,
+          label,
+          onDelete: () => onRemoveFilter(option.key)
+        }))
+    })
+  }
+
+  const filterChips = getFilterChips()
+
+  if (filterChips.length === 0) {
+    return null
+  }
+
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, flexWrap: 'wrap', mb: 3 }}>
+      <Typography 
+        variant="body1" 
+        color="secondary.800" 
+        fontWeight="500"
+        sx={{ mr: 1 }}
+      >
+        Active filters:
+      </Typography>
+      
+      {filterChips.map(chip => (
+        <Chip
+          key={chip.key}
+          label={chip.label}
+          onDelete={chip.onDelete}
+          size="small"
+          variant="outlined"
+          sx={{
+            borderColor: 'secondary.500',
+            color: 'secondary.800',
+            '& .MuiChip-deleteIcon': {
+              color: 'secondary.800',
+              '&:hover': {
+                color: 'secondary.900'
+              }
+            },
+            '&:hover': {
+              backgroundColor: 'secondary.50'
+            }
+          }}
+        />
+      ))}
+      
+      <Button
+        variant="text"
+        size="small"
+        onClick={onClearAllFilters}
+        sx={{
+          textTransform: 'none',
+          color: 'secondary.800',
+          fontSize: '0.75rem',
+          minWidth: 'auto',
+          p: 0.5,
+          ml: 1
+        }}
+      >
+        Clear all filters
+      </Button>
+    </Box>
+  )
+}
+
+export default ActiveFilters

--- a/soft-skills-front/src/features/learn-to-learn/components/ui/EmptyState.tsx
+++ b/soft-skills-front/src/features/learn-to-learn/components/ui/EmptyState.tsx
@@ -1,0 +1,119 @@
+import { Box, Typography, Button } from '@mui/material'
+import { ReactNode } from 'react'
+import { FolderOpen } from '@mui/icons-material'
+
+interface EmptyStateProps {
+  title: string
+  description: string
+  image?: string
+  icon?: ReactNode
+  buttonText?: string
+  onButtonClick?: () => void
+  maxWidth?: string
+  minHeight?: string
+  fullHeight?: boolean
+}
+
+const EmptyState = ({ 
+  title, 
+  description, 
+  image,
+  icon,
+  buttonText,
+  onButtonClick,
+  maxWidth = '500px',
+  minHeight = '400px',
+  fullHeight = false
+}: EmptyStateProps) => {
+  const renderVisual = () => {
+    if (image) {
+      return (
+        <Box
+          component="img"
+          src={image}
+          alt="Empty state illustration"
+          sx={{
+            width: '200px',
+            height: '200px',
+            objectFit: 'contain',
+            mb: 2
+          }}
+        />
+      )
+    }
+
+    return (
+      <Box
+        sx={{ 
+          color: 'text.secondary',
+          mb: 2
+        }}
+      >
+        {
+            icon || 
+            <FolderOpen sx={{ 
+                fontSize: '4rem' 
+            }} />
+        }
+      </Box>
+    )
+  }
+
+  return (
+    <Box
+      sx={{
+        maxWidth,
+        mx: 'auto',
+        px: 2,
+        py: fullHeight ? 0 : 4,
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'center',
+        alignItems: 'center',
+        minHeight: fullHeight ? 'calc(100vh - 176px)' : minHeight,
+        textAlign: 'center',
+        gap: 1,
+      }}
+    >
+      {renderVisual()}
+
+      <Typography 
+        variant="h5" 
+        component="h2" 
+        fontWeight="600"
+        color="text.primary"
+        gutterBottom
+      >
+        {title}
+      </Typography>
+      
+      <Typography 
+        variant="body1" 
+        color="text.secondary" 
+        sx={{ 
+            mb: buttonText ? 3 : 0, 
+            lineHeight: 1.6 
+        }}
+      >
+        {description}
+      </Typography>
+
+      {buttonText && onButtonClick && (
+        <Button 
+          variant="contained" 
+          color="secondary"
+          onClick={onButtonClick}
+          sx={{ 
+            px: 3,
+            py: 1,
+            fontWeight: 500
+          }}
+        >
+          {buttonText}
+        </Button>
+      )}
+    </Box>
+  )
+}
+
+export default EmptyState

--- a/soft-skills-front/src/features/learn-to-learn/hooks/usePublicRoadmaps.ts
+++ b/soft-skills-front/src/features/learn-to-learn/hooks/usePublicRoadmaps.ts
@@ -1,0 +1,26 @@
+import { useQuery } from '@tanstack/react-query'
+import { getPublicRoadmaps } from '../api/Roadmaps'
+import { PublicRoadmapsParams } from '../types/roadmap/roadmap.api'
+
+interface UsePublicRoadmapsParams extends PublicRoadmapsParams {
+  page?: number
+  pageSize?: number
+}
+
+export function usePublicRoadmaps(params: UsePublicRoadmapsParams = {}) {
+  const { page = 1, pageSize = 12, ...filterParams } = params
+  const offset = (page - 1) * pageSize
+
+  const queryParams: PublicRoadmapsParams = {
+    ...filterParams,
+    offset,
+    limit: pageSize
+  }
+
+  return useQuery({
+    queryKey: ['publicRoadmaps', queryParams],
+    queryFn: () => getPublicRoadmaps(queryParams),
+    staleTime: 60_000,
+    placeholderData: (previousData) => previousData,
+  })
+}

--- a/soft-skills-front/src/features/learn-to-learn/pages/Explore.tsx
+++ b/soft-skills-front/src/features/learn-to-learn/pages/Explore.tsx
@@ -1,8 +1,245 @@
+import {
+  Box,
+  Typography,
+  Grid2,
+  Button,
+  CircularProgress,
+  Alert
+} from '@mui/material'
+import { useEffect, useMemo } from 'react'
+import { useNavigate, useSearchParams } from 'react-router-dom'
+import RoadmapCard from '../components/roadmap/RoadmapCard'
+import { usePublicRoadmaps } from '../hooks/usePublicRoadmaps'
+import { useDebounce } from '../hooks/useDebounce'
+import EmptyState from '../components/ui/EmptyState'
+import PaginationControls from '../components/PaginationControls'
+import DataFilter from '../components/ui/DataFilter'
+import ActiveFilters from '../components/ui/ActiveFilters'
+import { FilterOption } from '../types/ui/filter.types'
+import { useExploreStore } from '../store/useExploreStore'
+
 const Explore = () => {
+  const navigate = useNavigate()
+  const [searchParams, setSearchParams] = useSearchParams()
+
+  const {
+    searchTerm,
+    selectedFilters,
+    appliedFilters,
+    page,
+    pageSize,
+    setSearchTerm,
+    updateFilter,
+    applyFilters,
+    setPage,
+    setPageSize,
+    clearFilters
+  } = useExploreStore()
+
+  useEffect(() => {
+    const urlSearch = searchParams.get('search') || ''
+    const urlAuthor = searchParams.get('authorId')
+    const urlPage = parseInt(searchParams.get('page') || '1')
+    const urlPageSize = parseInt(searchParams.get('pageSize') || '12')
+
+    if (urlSearch !== searchTerm) setSearchTerm(urlSearch)
+    if (urlAuthor && !appliedFilters.author.includes(urlAuthor)) {
+      updateFilter('author', [urlAuthor])
+      applyFilters()
+    }
+    if (urlPage !== page) setPage(urlPage)
+    if (urlPageSize !== pageSize) setPageSize(urlPageSize)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const debouncedSearch = useDebounce(searchTerm, 300)
+
+  const queryParams = useMemo(() => {
+    let minSteps: number | undefined = undefined
+    let maxSteps: number | undefined = undefined
+    
+    if (appliedFilters.stepsRange.length > 0) {
+      const [min, max] = appliedFilters.stepsRange[0].split('-')
+      
+      if (min) minSteps = parseInt(min)
+      if (max) maxSteps = parseInt(max)
+    }
+
+    return {
+      search: debouncedSearch || undefined, 
+      authorId: appliedFilters.author.length > 0 ? appliedFilters.author[0] : undefined,
+      minSteps,
+      maxSteps,
+      page,
+      pageSize
+    }
+  }, [debouncedSearch, appliedFilters, page, pageSize])
+
+  const { data, isLoading, error, refetch } = usePublicRoadmaps(queryParams)
+
+
+  useEffect(() => {
+    const params = new URLSearchParams()
+    if (debouncedSearch) params.set('search', debouncedSearch)
+    
+    if (appliedFilters.author.length > 0) params.set('authorId', appliedFilters.author[0])
+    if (appliedFilters.stepsRange.length > 0) {
+      const [min, max] = appliedFilters.stepsRange[0].split('-')
+      if (min) params.set('minSteps', min)
+      if (max) params.set('maxSteps', max)
+    }
+    
+    if (page !== 1) params.set('page', page.toString())
+    if (pageSize !== 12) params.set('pageSize', pageSize.toString())
+    
+    setSearchParams(params, { replace: true })
+  }, [debouncedSearch, appliedFilters, page, pageSize, setSearchParams])
+
+  const handleSearchChange = (search: string) => {
+    setSearchTerm(search)
+  }
+
+  const handleFilterChange = (filterKey: string, values: string[]) => {
+    updateFilter(filterKey, values)
+  }
+
+  const handleApplyFilters = () => {
+    applyFilters()
+  }
+
+  const handleRemoveFilter = (filterKey: string) => {
+    updateFilter(filterKey, [])
+    applyFilters()
+  }
+
+  const handleViewRoadmap = (roadmapId: string) => {
+    navigate(`/learn/explore/${roadmapId}`)
+  }
+
+  const handlePageChange = (newOffset: number) => {
+    const newPage = Math.floor(newOffset / pageSize) + 1
+    setPage(newPage)
+  }
+
+  const handlePageSizeChange = (newPageSize: number) => {
+    setPageSize(newPageSize)
+  }
+
+  const filterOptions: FilterOption[] = [
+    {
+      key: 'author',
+      label: 'Author',
+      type: 'text',
+      placeholder: 'Enter author name'
+    },
+    {
+      key: 'stepsRange',
+      label: 'Steps Range',
+      type: 'range',
+      minPlaceholder: 'min steps',
+      maxPlaceholder: 'max steps'
+    }
+  ]
+
+  const roadmaps = data?.data || []
+  const total = data?.total || 0
+  const isEmpty = !isLoading && roadmaps.length === 0
+  const hasResults = roadmaps.length > 0
+  const isInitialLoading = isLoading && roadmaps.length === 0
+
+
   return (
-    <>
-      <h1>Explore view page</h1>
-    </>
+    <Box p={4}>
+      <Box mb={4}>
+        <Typography variant="h4" fontWeight="bold">
+          Explore public roadmaps
+        </Typography>
+        <Typography variant="subtitle1" color="text.secondary">
+          Discover learning paths created by the community
+        </Typography>
+      </Box>
+
+      <DataFilter
+        searchPlaceholder="Search public roadmaps..."
+        filterButtonText="Filter Roadmaps"
+        searchValue={searchTerm}
+        onSearchChange={handleSearchChange}
+        filterOptions={filterOptions}
+        selectedFilters={selectedFilters}
+        onFilterChange={handleFilterChange}
+        onApplyFilters={handleApplyFilters}
+        applyButtonText="Apply filters"
+      />
+
+      <ActiveFilters
+        appliedFilters={appliedFilters}
+        filterOptions={filterOptions}
+        onRemoveFilter={handleRemoveFilter}
+        onClearAllFilters={clearFilters}
+      />
+
+      {error && (
+        <Alert 
+          severity="error" 
+          action={
+            <Button color="inherit" size="small" onClick={() => refetch()}>
+              Retry
+            </Button>
+          }
+          sx={{ mb: 3 }}
+        >
+          Failed to load roadmaps. Please try again.
+        </Alert>
+      )}
+
+      {isInitialLoading && (
+        <Box display="flex" justifyContent="center" py={6}>
+          <CircularProgress />
+        </Box>
+      )}
+
+      {hasResults && (
+        <>
+          <Typography variant="body2" color="text.secondary" mb={3}>
+            Showing {roadmaps.length} of {total} roadmaps
+          </Typography>
+          
+          <Grid2 container spacing={3} mb={4}>
+            {roadmaps.map((roadmap) => (
+              <Grid2
+                key={roadmap.roadmapId}
+                size={{ xs: 12, sm: 6, md: 4, lg: 3 }}
+                display="flex"
+              >
+                <RoadmapCard
+                  roadmapSummary={roadmap}
+                  onViewClick={() => handleViewRoadmap(roadmap.roadmapId)}
+                  mode="public"
+                />
+              </Grid2>
+            ))}
+          </Grid2>
+
+          <PaginationControls
+            total={total}
+            offset={(page - 1) * pageSize}
+            limit={pageSize}
+            onChangeOffset={handlePageChange}
+            onChangeLimit={handlePageSizeChange}
+            pageSizeOptions={[12, 24, 36]}
+          />
+        </>
+      )}
+
+      {isEmpty && (
+        <EmptyState
+          title="No public roadmaps found"
+          description="Try adjusting your search terms or filters to find more roadmaps."
+          buttonText="Clear Filters"
+          onButtonClick={clearFilters}
+        />
+      )}
+    </Box>
   )
 }
 

--- a/soft-skills-front/src/features/learn-to-learn/pages/RoadmapDetail.tsx
+++ b/soft-skills-front/src/features/learn-to-learn/pages/RoadmapDetail.tsx
@@ -10,9 +10,11 @@ import ArrowBackIcon from '@mui/icons-material/ArrowBack'
 import CalendarTodayIcon from '@mui/icons-material/CalendarToday'
 import MenuBookIcon from '@mui/icons-material/MenuBook'
 import EditIcon from '@mui/icons-material/Edit'
+import ContentCopyIcon from '@mui/icons-material/ContentCopy'
+import PersonIcon from '@mui/icons-material/Person'
 import PublicIcon from '@mui/icons-material/Public'
 import LockIcon from '@mui/icons-material/Lock'
-import { useNavigate, useParams } from 'react-router-dom'
+import { useNavigate, useParams, useLocation } from 'react-router-dom'
 import { formatDateString } from '../../../utils/formatDate'
 import { useRoadmapStore } from '../store/useRoadmapStore'
 import { useEffect } from 'react'
@@ -21,6 +23,9 @@ import RoadmapFlow from '../components/roadmap/RoadmapFlow'
 const RoadmapDetail = () => {
   const { roadmapId } = useParams()
   const navigate = useNavigate()
+  const location = useLocation()
+
+  const isPublicMode = location.pathname.startsWith('/learn/explore')
 
   const {
     selectedRoadmap,
@@ -39,7 +44,15 @@ const RoadmapDetail = () => {
   }
 
   const handleBackToRoadmaps = () => {
-    navigate('/learn/roadmaps')
+    if (isPublicMode) {
+      navigate('/learn/explore')
+    } else {
+      navigate('/learn/roadmaps')
+    }
+  }
+
+  const handleCopyRoadmap = () => {
+    console.log('Copy roadmap:', roadmapId)
   }
 
   useEffect(() => {
@@ -69,17 +82,27 @@ const RoadmapDetail = () => {
             <ArrowBackIcon fontSize="small" />
           </IconButton>
           <Typography variant="body2" fontWeight="medium" color="text.secondary">
-            Back to roadmaps
+            {isPublicMode ? 'Back to explore' : 'Back to roadmaps'}
           </Typography>
         </Stack>
 
-        <Button
-          variant="contained"
-          startIcon={<EditIcon />}
-          onClick={() => navigate(`/learn/roadmaps/${roadmapId}/edit`)}
-        >
-          Edit Roadmap
-        </Button>
+        {isPublicMode ? (
+          <Button
+            variant="contained"
+            startIcon={<ContentCopyIcon />}
+            onClick={handleCopyRoadmap}
+          >
+            Copy Roadmap
+          </Button>
+        ) : (
+          <Button
+            variant="contained"
+            startIcon={<EditIcon />}
+            onClick={() => navigate(`/learn/roadmaps/${roadmapId}/edit`)}
+          >
+            Edit Roadmap
+          </Button>
+        )}
       </Stack>
 
       <Stack direction="row" alignItems="center" spacing={1} mb={1}>
@@ -92,6 +115,26 @@ const RoadmapDetail = () => {
           <LockIcon sx={{ color: 'text.secondary', fontSize: '1.5rem' }} />
         )}
       </Stack>
+      
+      {isPublicMode && (
+        <Stack 
+          direction="row" 
+          alignItems="center" 
+          spacing={1} 
+          mb={1}
+        >
+          <PersonIcon 
+            sx={{ 
+              fontSize: '1rem', 
+              color: 'text.secondary' 
+            }} 
+          />
+          <Typography variant="body1" color="text.secondary">
+            Created by <strong>{selectedRoadmap.username || 'Unknown Author'}</strong>
+          </Typography>
+        </Stack>
+      )}
+      
       <Typography variant="subtitle1" color="text.secondary" mb={2}>
         {selectedRoadmap.description}
       </Typography>

--- a/soft-skills-front/src/features/learn-to-learn/pages/Roadmaps.tsx
+++ b/soft-skills-front/src/features/learn-to-learn/pages/Roadmaps.tsx
@@ -15,6 +15,7 @@ import { useNavigate } from 'react-router-dom'
 import CreateRoadmapModal from '../components/roadmap/CreateRoadmapModal'
 import { RoadmapSummary } from '../types/roadmap/roadmap.models'
 import ConfirmDeleteModal from '../components/ConfirmDeleteModal'
+import EmptyState from '../components/ui/EmptyState'
 
 const Roadmaps = () => {
   const [showCreateModal, setShowCreateModal] = useState(false)
@@ -75,17 +76,19 @@ const Roadmaps = () => {
           </Typography>
         </Box>
 
-        <Button
-          variant="contained"
-          color="secondary"
-          startIcon={<AddIcon />}
-          sx={{
-            fontWeight: 500,
-          }}
-          onClick={() => setShowCreateModal(true)}
-        >
-          Create new roadmap
-        </Button>
+        {hasMyRoadmaps && (
+          <Button
+            variant="contained"
+            color="secondary"
+            startIcon={<AddIcon />}
+            sx={{
+              fontWeight: 500,
+            }}
+            onClick={() => setShowCreateModal(true)}
+          >
+            Create new roadmap
+          </Button>
+        )}
       </Stack>
 
       <Box>
@@ -116,14 +119,26 @@ const Roadmaps = () => {
           </Grid2>
         )}
 
-        <PaginationControls
-          total={total}
-          offset={offset}
-          limit={limit}
-          onChangeOffset={setMyRoadmapsOffset}
-          onChangeLimit={setMyRoadmapsLimit}
-          pageSizeOptions={[10, 25, 50]}
-        />
+        {isEmpty && (
+          <EmptyState
+            title="No roadmaps yet"
+            description="Start your learning journey by creating your first personalized roadmap. Build structured paths to achieve your goals."
+            buttonText="Create your first roadmap"
+            onButtonClick={() => setShowCreateModal(true)}
+            fullHeight
+          />
+        )}
+
+        {hasMyRoadmaps && (
+          <PaginationControls
+            total={total}
+            offset={offset}
+            limit={limit}
+            onChangeOffset={setMyRoadmapsOffset}
+            onChangeLimit={setMyRoadmapsLimit}
+            pageSizeOptions={[10, 25, 50]}
+          />
+        )}
       </Box>
       <CreateRoadmapModal
         open={showCreateModal}

--- a/soft-skills-front/src/features/learn-to-learn/store/useExploreStore.ts
+++ b/soft-skills-front/src/features/learn-to-learn/store/useExploreStore.ts
@@ -1,0 +1,90 @@
+import { create } from 'zustand'
+import { devtools } from 'zustand/middleware'
+import { immer } from 'zustand/middleware/immer'
+import { IExploreStore } from '../types/explore/explore.store'
+import { SelectedFilters } from '../components/ui/DataFilter'
+
+const initialState = {
+  searchTerm: '',
+  selectedFilters: {
+    author: [],
+    stepsRange: []
+  },
+  appliedFilters: {
+    author: [],
+    stepsRange: []
+  },
+  page: 1,
+  pageSize: 12
+}
+
+export const useExploreStore = create<IExploreStore>()(
+  devtools(
+    immer((set) => ({
+      ...initialState,
+
+      setSearchTerm: (searchTerm: string) => {
+        set((state) => {
+          state.searchTerm = searchTerm
+          state.page = 1
+        }, false, 'EXPLORE/SET_SEARCH_TERM')
+      },
+
+      setSelectedFilters: (filters: SelectedFilters) => {
+        set((state) => {
+          state.selectedFilters = filters
+          state.appliedFilters = filters
+          state.page = 1
+        }, false, 'EXPLORE/SET_SELECTED_FILTERS')
+      },
+
+      updateFilter: (filterKey: string, values: string[]) => {
+        set((state) => {
+          state.selectedFilters[filterKey] = values
+        }, false, 'EXPLORE/UPDATE_FILTER')
+      },
+
+      applyFilters: () => {
+        set((state) => {
+          state.appliedFilters = { ...state.selectedFilters }
+          state.page = 1
+        }, false, 'EXPLORE/APPLY_FILTERS')
+      },
+
+      setPage: (page: number) => {
+        set((state) => {
+          state.page = page
+        }, false, 'EXPLORE/SET_PAGE')
+      },
+
+      setPageSize: (pageSize: number) => {
+        set((state) => {
+          state.pageSize = pageSize
+          state.page = 1
+        }, false, 'EXPLORE/SET_PAGE_SIZE')
+      },
+
+      clearFilters: () => {
+        set((state) => {
+          state.searchTerm = ''
+          state.selectedFilters = {
+            author: [],
+            stepsRange: []
+          }
+          state.appliedFilters = {
+            author: [],
+            stepsRange: []
+          }
+          state.page = 1
+        }, false, 'EXPLORE/CLEAR_FILTERS')
+      },
+
+      resetAll: () => {
+        set((state) => {
+          Object.assign(state, initialState)
+        }, false, 'EXPLORE/RESET_ALL')
+      }
+    })),
+    { name: 'exploreStore' }
+  )
+)

--- a/soft-skills-front/src/features/learn-to-learn/store/useRoadmapStore.ts
+++ b/soft-skills-front/src/features/learn-to-learn/store/useRoadmapStore.ts
@@ -4,7 +4,7 @@ import { immer } from 'zustand/middleware/immer'
 import { IRoadmapStore } from '../types/roadmap/roadmap.store'
 import { useToastStore } from '../../../store/useToastStore'
 import { LayoutNode, OnlyRoadmapMetadata, Roadmap, RoadmapSummary } from '../types/roadmap/roadmap.models'
-import { createRoadmap, deleteRoadmap, getPublicRoadmaps, getRoadmapById, getUserRoadmaps, updateRoadmap } from '../api/Roadmaps'
+import { createRoadmap, deleteRoadmap, getRoadmapById, getUserRoadmaps, updateRoadmap } from '../api/Roadmaps'
 import { buildRoadmapLayout } from '../utils/roadmap/roadmapLayoutGenerator'
 import { addTaskToObjective, countAllTasks, findObjectiveById, findTaskById, findTaskInObjective, getOrCreateOrphanObjective, insertObjectiveRelativeToTarget, reindexObjectives, removeObjectiveById, removeTaskFromObjective, removeTaskFromOrphanObjective, updateObjectiveTitle, updateTaskTitle } from '../utils/roadmap/roadmapStructureUtils'
 import { createObjectiveFromNode, createTaskFromNode, findEdgeByNodeId, findNodeById, findNodeIndexById, getNodeTitle, removeEdgesByIds, removeEdgesConnectedToNode, removeNodeById, removeNodesByIds, updateObjectiveTaskCount } from '../utils/roadmap/roadmapGraphHelpers'
@@ -18,19 +18,12 @@ export const useRoadmapStore = create<IRoadmapStore>()(
       editorEdges: [],
 
       myRoadmaps: [],
-      publicRoadmaps: [],
       isLoading: false,
 
       myRoadmapsPagination: {
         total: 0,
         offset: 0,
         limit: 10,
-      },
-
-      publicRoadmapsPagination: {
-        offset: 0,
-        limit: 10,
-        total: 0,
       },
 
       selectedRoadmap: null,
@@ -44,11 +37,6 @@ export const useRoadmapStore = create<IRoadmapStore>()(
         }, false, 'ROADMAP/SET_MY_ROADMAPS')
       },
 
-      setPublicRoadmaps: (roadmaps: RoadmapSummary[]) => {
-        set((state) => {
-          state.publicRoadmaps = roadmaps
-        }, false, 'ROADMAP/SET_PUBLIC_ROADMAPS')
-      },
 
       setMyRoadmapsOffset: (offset: number) => {
         set((state) => {
@@ -56,11 +44,6 @@ export const useRoadmapStore = create<IRoadmapStore>()(
         }, false, 'ROADMAP/SET_MY_OFFSET')
       },
 
-      setPublicRoadmapsOffset: (offset: number) => {
-        set((state) => {
-          state.publicRoadmapsPagination.offset = offset
-        }, false, 'ROADMAP/SET_PUBLIC_OFFSET')
-      },
 
       setMyRoadmapsLimit: (limit: number) => {
         set((state) => {
@@ -68,11 +51,6 @@ export const useRoadmapStore = create<IRoadmapStore>()(
         }, false, 'ROADMAP/SET_MY_LIMIT')
       },
 
-      setPublicRoadmapsLimit: (limit: number) => {
-        set((state) => {
-          state.publicRoadmapsPagination.limit = limit
-        }, false, 'ROADMAP/SET_PUBLIC_LIMIT')
-      },
 
       setMyRoadmapsTotal: (total: number) => {
         set((state) => {
@@ -80,11 +58,6 @@ export const useRoadmapStore = create<IRoadmapStore>()(
         }, false, 'ROADMAP/SET_MY_TOTAL')
       },
 
-      setPublicRoadmapsTotal: (total: number) => {
-        set((state) => {
-          state.publicRoadmapsPagination.total = total
-        }, false, 'ROADMAP/SET_PUBLIC_TOTAL')
-      },
 
       setSelectedRoadmap: (roadmap: Roadmap | null) => {
         set((state) => {
@@ -288,29 +261,6 @@ export const useRoadmapStore = create<IRoadmapStore>()(
         }
       },
 
-      fetchPublicRoadmaps: async (offset?: number, limit?: number) => {
-        const currentOffset = offset ?? get().publicRoadmapsPagination.offset
-        const currentLimit = limit ?? get().publicRoadmapsPagination.limit
-
-        set((state) => {
-          state.isLoading = true
-        }, false, 'ROADMAP/FETCH_PUBLIC_REQUEST')
-
-        try {
-          const { data, total } = await getPublicRoadmaps(currentOffset, currentLimit)
-
-          get().setPublicRoadmaps(data)
-          get().setPublicRoadmapsTotal(total)
-        } catch (err: unknown) {
-          if (err instanceof Error) {
-            useToastStore.getState().showToast(err.message || 'Error fetching public roadmaps', 'error')
-          }
-        } finally {
-          set((state) => {
-            state.isLoading = false
-          }, false, 'ROADMAP/FETCH_PUBLIC_COMPLETE')
-        }
-      },
 
       getRoadmapById: async (id: string, editable: boolean = false) => {
         set((state) => {

--- a/soft-skills-front/src/features/learn-to-learn/types/explore/explore.store.ts
+++ b/soft-skills-front/src/features/learn-to-learn/types/explore/explore.store.ts
@@ -1,0 +1,18 @@
+import { SelectedFilters } from "../../components/ui/DataFilter"
+
+export interface IExploreStore {
+  searchTerm: string
+  selectedFilters: SelectedFilters
+  appliedFilters: SelectedFilters
+  page: number
+  pageSize: number
+  
+  setSearchTerm: (searchTerm: string) => void
+  setSelectedFilters: (filters: SelectedFilters) => void
+  updateFilter: (filterKey: string, values: string[]) => void
+  applyFilters: () => void
+  setPage: (page: number) => void
+  setPageSize: (pageSize: number) => void
+  clearFilters: () => void
+  resetAll: () => void
+}

--- a/soft-skills-front/src/features/learn-to-learn/types/roadmap/roadmap.api.ts
+++ b/soft-skills-front/src/features/learn-to-learn/types/roadmap/roadmap.api.ts
@@ -4,7 +4,17 @@ export interface FetchRoadmapsSummaryResponse {
   data: RoadmapSummary[]
   total: number
 }
+
 export interface CreateRoadmapPayload {
   title: string
   description: string
+}
+
+export interface PublicRoadmapsParams {
+  search?: string
+  authorId?: string
+  minSteps?: number
+  maxSteps?: number
+  offset?: number
+  limit?: number
 }

--- a/soft-skills-front/src/features/learn-to-learn/types/roadmap/roadmap.models.ts
+++ b/soft-skills-front/src/features/learn-to-learn/types/roadmap/roadmap.models.ts
@@ -84,6 +84,7 @@ export interface Roadmap {
   objectives: Objective[]
   layout?: Layout 
   userId: string
+  username: string
   visibility: RoadmapVisibility
   createdAt: string | null
   updatedAt: string | null
@@ -92,6 +93,7 @@ export interface Roadmap {
 export interface RoadmapSummary {
   roadmapId: string
   title: string
+  username: string
   description?: string
   createdAt: string | null
   stepsCount: number

--- a/soft-skills-front/src/features/learn-to-learn/types/roadmap/roadmap.store.ts
+++ b/soft-skills-front/src/features/learn-to-learn/types/roadmap/roadmap.store.ts
@@ -28,31 +28,24 @@ export interface IRoadmapStore {
   selectedRoadmapSteps: number
 
   myRoadmaps: RoadmapSummary[]
-  publicRoadmaps: RoadmapSummary[]
 
   isLoading: boolean
 
   myRoadmapsPagination: PaginationState
-  publicRoadmapsPagination: PaginationState
 
   setMyRoadmaps: (roadmaps: RoadmapSummary[]) => void
-  setPublicRoadmaps: (roadmaps: RoadmapSummary[]) => void
 
   setSelectedRoadmap: (roadmap: Roadmap | null) => void
   setSelectedRoadmapMetadata: (metadata: OnlyRoadmapMetadata) => void
   setSelectedRoadmapSteps: (stepsCount: number) => void
 
   setMyRoadmapsOffset: (offset: number) => void
-  setPublicRoadmapsOffset: (offset: number) => void
 
   setMyRoadmapsLimit: (limit: number) => void
-  setPublicRoadmapsLimit: (limit: number) => void
 
   setMyRoadmapsTotal: (total: number) => void
-  setPublicRoadmapsTotal: (total: number) => void
 
   fetchMyRoadmaps: (offset?: number, limit?: number) => Promise<void>
-  fetchPublicRoadmaps: (offset?: number, limit?: number) => Promise<void>
 
   getRoadmapById: (id: string, editable?: boolean) => Promise<void>
   deleteRoadmap: (id: string) => Promise<void>

--- a/soft-skills-front/src/features/learn-to-learn/types/ui/filter.types.ts
+++ b/soft-skills-front/src/features/learn-to-learn/types/ui/filter.types.ts
@@ -1,4 +1,4 @@
-export type FilterType = 'checkbox' | 'select'
+export type FilterType = 'checkbox' | 'select' | 'text' | 'range'
 
 export type TabValue = 'all' | 'incomplete' | 'ongoing' | 'finished'
 
@@ -16,5 +16,7 @@ export interface FilterOption {
   label: string
   placeholder?: string
   type: FilterType
-  values: FilterValue[]
+  values?: FilterValue[] 
+  minPlaceholder?: string 
+  maxPlaceholder?: string
 }

--- a/soft-skills-front/src/routes/routes.tsx
+++ b/soft-skills-front/src/routes/routes.tsx
@@ -51,7 +51,10 @@ export const RoutesConfiguration = () => {
             </Route>
             
             <Route path='dashboard' element={<Dashboard/>}></Route>
-            <Route path='explore' element={<Explore/>}></Route>
+            <Route path='explore'>
+              <Route index element={<Explore/>} />
+              <Route path=':roadmapId' element={<RoadmapDetail />} />
+            </Route>
             <Route path='reports' element={<LearningReport/>}></Route>
             
             <Route path='roadmaps'>

--- a/soft-skills-front/src/theme.ts
+++ b/soft-skills-front/src/theme.ts
@@ -8,6 +8,13 @@ const theme = createTheme({
     },
     secondary: {
       main: "#2383E2",
+      50: "#e3f2fd",
+      100: "#bbdefb", 
+      200: "#90caf9",
+      500: "#2196f3",
+      600: "#1e88e5",
+      800: "#1565c0",
+      900: "#0d47a1",
     },
     background: {
       default: "#FFFFFF",


### PR DESCRIPTION
What:
- Implemented `/learn/explore` page with search bar, filter column (steps and author), and grid layout.
- Created `usePublicRoadmaps` hook with React Query for fetching public roadmaps.
- Added `PublicRoadmapCard` component with author, steps count and "View Roadmap" action.
- Integrated pagination and placeholder data for smoother UX.
- Updated roadmap detail view to support public mode (shows author, replaces "Edit Roadmap" with "Copy Roadmap").

Why:
- Enables users to discover and explore community/shared roadmaps.
- Separates public roadmap browsing (server state) from private roadmap editing (client state).